### PR TITLE
修复一个导致在最新版本的VS2017中编译不通过的问题

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@
 *.sqlite
 *.json
 /XAntiDebug/resource.h
+*.opendb

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,9 @@
 *.exe
 *.out
 *.app
+*.ipch
+*.db
+*.suo
+*.sqlite
+*.json
+/XAntiDebug/resource.h

--- a/XAntiDebug/XAntiDebug.cpp
+++ b/XAntiDebug/XAntiDebug.cpp
@@ -114,22 +114,17 @@ XAD_STATUS XAntiDebug::initialize()
 	if (_isX64)
 	{
 		_MyQueryInfomationProcess  = (DWORD64)GetProcAddress64(GetModuleHandle64(XAD_NTDLL), "ZwQueryInformationProcess");
-		if (_MyQueryInfomationProcess == NULL)
-		{
-			return XAD_ERROR_NTAPI;
-		}
 		_MyQueryInfomationProcess -= (DWORD64)GetModuleHandle64(XAD_NTDLL);
 	}
 	else
 	{
 		_MyQueryInfomationProcess = (DWORD)GetProcAddress(GetModuleHandle(XAD_NTDLL), "ZwQueryInformationProcess");
-		if (_MyQueryInfomationProcess == NULL)
-		{
-			return XAD_ERROR_NTAPI;
-		}
 		_MyQueryInfomationProcess -= (DWORD)GetModuleHandle(XAD_NTDLL);
 	}
-
+	if (_MyQueryInfomationProcess == NULL)
+	{
+		return XAD_ERROR_NTAPI;
+	}
 
 	// rva to raw
 	DWORD	fileOffset = 0;
@@ -249,7 +244,7 @@ XAD_STATUS XAntiDebug::initialize()
 		0x0F, 0x05,					// syscall
 		0xC3						// retn
 	};
-	_executePage = VirtualAllocEx((HANDLE)-1, 0, 0x1000, MEM_COMMIT, PAGE_EXECUTE_READWRITE);
+	_executePage = VirtualAllocEx((HANDLE)-1, 0, 0x1000, MEM_COMMIT | MEM_TOP_DOWN, PAGE_EXECUTE_READWRITE);
 	if (_executePage == NULL)
 	{
 		return XAD_ERROR_ALLOCMEM;
@@ -259,11 +254,6 @@ XAD_STATUS XAntiDebug::initialize()
 	ULONG_PTR		pSysCall;
 
 	srand(GetTickCount());
-	unsigned char *pRandChar = (unsigned char *)_executePage;
-	for (int i = 0; i < 0x1000; i++)
-	{
-		pRandChar[i] = LOBYTE(rand());
-	}
 	random = rand() % 0x800 + 0x100;
 
 	//copy ssdt index to opcode

--- a/XAntiDebug/XAntiDebug.h
+++ b/XAntiDebug/XAntiDebug.h
@@ -26,6 +26,7 @@
 #endif // !_WIN64
 
 
+
 #define XAD_NTDLL	L"ntdll.dll"
 #define	XAD_PEHAD	0x1000
 

--- a/XAntiDebug/XAntiDebug.h
+++ b/XAntiDebug/XAntiDebug.h
@@ -22,7 +22,7 @@
 #include "crc32.h"
 
 #ifndef _WIN64
-#include "wow64ext.h"
+#include <wow64ext.h>
 #endif // !_WIN64
 
 
@@ -63,5 +63,5 @@ private:
 	fn_SysCall32	pfnSyscall32 = NULL;
 	fn_SysCall64	pfnSyscall64 = NULL;
 };
-
+void getMem64(void* dstMem, DWORD64 srcMem, size_t sz);
 #endif

--- a/XAntiDebug/XAntiDebug.h
+++ b/XAntiDebug/XAntiDebug.h
@@ -26,7 +26,6 @@
 #endif // !_WIN64
 
 
-
 #define XAD_NTDLL	L"ntdll.dll"
 #define	XAD_PEHAD	0x1000
 

--- a/XAntiDebug/sdkext.h
+++ b/XAntiDebug/sdkext.h
@@ -1,0 +1,552 @@
+/**
+*
+* WOW64Ext Library
+*
+* Copyright (c) 2014 ReWolf
+* http://blog.rewolf.pl/
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+
+#pragma once
+#include <winternl.h>
+//#include <ntexapi.h>
+
+
+
+#pragma warning(push)
+#pragma warning(disable: 4201)
+namespace sdkext
+{
+
+#pragma region Basic Type
+    using PVOID     = void *;
+    using PVOID32   = void * __ptr32;
+    using PVOID64   = void * __ptr64;
+
+    using HANDLE    = PVOID;
+    using HANDLE32  = PVOID32;
+    using HANDLE64  = PVOID64;
+
+    struct CLIENT_ID64
+    {
+        HANDLE64    UniqueProcess;
+        HANDLE64    UniqueThread;
+    };
+
+    struct LIST_ENTRY64
+    {
+        PVOID64     Flink;
+        PVOID64     Blink;
+    };
+
+    typedef struct X_STRING64
+    {
+        UINT16      Length;
+        UINT16      MaximumLength;
+        PVOID64     Buffer;
+    }ANSI_STRING64, *PANSI_STRING64, UNICODE_STRING64, *PUNICODE_STRING64;
+
+    struct CURDIR64
+    {
+        X_STRING64  DosPath;
+        HANDLE64    Handle;
+    };
+#pragma endregion
+
+
+#pragma region CONTEXT
+    enum Context64Flags : long
+    {
+        CONTEXT_ARCH                = 0x00100000L,
+
+        CONTEXT64_CONTROL           = (CONTEXT_ARCH | 0x00000001L),
+        CONTEXT64_INTEGER           = (CONTEXT_ARCH | 0x00000002L),
+        CONTEXT64_SEGMENTS          = (CONTEXT_ARCH | 0x00000004L),
+        CONTEXT64_FLOATING_POINT    = (CONTEXT_ARCH | 0x00000008L),
+        CONTEXT64_DEBUG_REGISTERS   = (CONTEXT_ARCH | 0x00000010L),
+
+        CONTEXT64_FULL      = (CONTEXT64_CONTROL | CONTEXT64_INTEGER | CONTEXT64_FLOATING_POINT),
+        CONTEXT64_ALL       = (CONTEXT64_CONTROL | CONTEXT64_INTEGER | CONTEXT64_SEGMENTS | CONTEXT64_FLOATING_POINT | CONTEXT64_DEBUG_REGISTERS),
+
+        CONTEXT64_XSTATE    = (CONTEXT_ARCH | 0x00000040L),
+    };
+
+
+    typedef struct DECLSPEC_ALIGN(16) XSAVE_FORMAT64 {
+        UINT16  ControlWord;
+        UINT16  StatusWord;
+        UINT8   TagWord;
+        UINT8   Reserved1;
+        UINT16  ErrorOpcode;
+        UINT32  ErrorOffset;
+        UINT16  ErrorSelector;
+        UINT16  Reserved2;
+        UINT32  DataOffset;
+        UINT16  DataSelector;
+        UINT16  Reserved3;
+        UINT32  MxCsr;
+        UINT32  MxCsr_Mask;
+        M128A   FloatRegisters[8];
+        M128A   XmmRegisters[16];
+        UINT8   Reserved4[96];
+
+    }*PXSAVE_FORMAT64;
+    typedef XSAVE_FORMAT64 XMM_SAVE_AREA64, *PXMM_SAVE_AREA64;
+
+
+    typedef struct DECLSPEC_ALIGN(16) CONTEXT64 {
+
+        //
+        // Register parameter home addresses.
+        //
+        // N.B. These fields are for convience - they could be used to extend the
+        //      context record in the future.
+        //
+
+        UINT64 P1Home;
+        UINT64 P2Home;
+        UINT64 P3Home;
+        UINT64 P4Home;
+        UINT64 P5Home;
+        UINT64 P6Home;
+
+        //
+        // Control flags.
+        //
+
+        UINT32 ContextFlags;
+        UINT32 MxCsr;
+
+        //
+        // Segment Registers and processor flags.
+        //
+
+        UINT16 SegCs;
+        UINT16 SegDs;
+        UINT16 SegEs;
+        UINT16 SegFs;
+        UINT16 SegGs;
+        UINT16 SegSs;
+        UINT32 EFlags;
+
+        //
+        // Debug registers
+        //
+
+        UINT64 Dr0;
+        UINT64 Dr1;
+        UINT64 Dr2;
+        UINT64 Dr3;
+        UINT64 Dr6;
+        UINT64 Dr7;
+
+        //
+        // Integer registers.
+        //
+
+        UINT64 Rax;
+        UINT64 Rcx;
+        UINT64 Rdx;
+        UINT64 Rbx;
+        UINT64 Rsp;
+        UINT64 Rbp;
+        UINT64 Rsi;
+        UINT64 Rdi;
+        UINT64 R8;
+        UINT64 R9;
+        UINT64 R10;
+        UINT64 R11;
+        UINT64 R12;
+        UINT64 R13;
+        UINT64 R14;
+        UINT64 R15;
+
+        //
+        // Program counter.
+        //
+
+        UINT64 Rip;
+
+        //
+        // Floating point state.
+        //
+
+        union {
+            XMM_SAVE_AREA64 FltSave;
+            struct {
+                M128A Header[2];
+                M128A Legacy[8];
+                M128A Xmm0;
+                M128A Xmm1;
+                M128A Xmm2;
+                M128A Xmm3;
+                M128A Xmm4;
+                M128A Xmm5;
+                M128A Xmm6;
+                M128A Xmm7;
+                M128A Xmm8;
+                M128A Xmm9;
+                M128A Xmm10;
+                M128A Xmm11;
+                M128A Xmm12;
+                M128A Xmm13;
+                M128A Xmm14;
+                M128A Xmm15;
+            } DUMMYSTRUCTNAME;
+        } DUMMYUNIONNAME;
+
+        //
+        // Vector registers.
+        //
+
+        M128A  VectorRegister[26];
+        UINT64 VectorControl;
+
+        //
+        // Special debug control registers.
+        //
+
+        UINT64 DebugControl;
+        UINT64 LastBranchToRip;
+        UINT64 LastBranchFromRip;
+        UINT64 LastExceptionToRip;
+        UINT64 LastExceptionFromRip;
+    }*PCONTEXT64;
+#pragma endregion
+
+
+#pragma region TEB
+    typedef struct NT_TIB64
+    {
+        PVOID64     ExceptionList;          // PEXCEPTION_REGISTRATION_RECORD
+        PVOID64     StackBase;
+        PVOID64     StackLimit;
+        PVOID64     SubSystemTib;
+        union
+        {
+            PVOID64 FiberData;
+            UINT32  Version;
+        };
+        PVOID64     ArbitraryUserPointer;
+        PVOID64     Self;                   // PNT_TIB64
+    }*PNT_TIB64;
+
+    typedef struct TEB64
+    {
+        NT_TIB64    NtTib;
+        PVOID64     EnvironmentPointer;
+        CLIENT_ID64 ClientId;
+        HANDLE64    ActiveRpcHandle;
+        PVOID64     ThreadLocalStoragePointer;
+        PVOID64     ProcessEnvironmentBlock; // PPEB64
+        UINT32      LastErrorValue;
+        UINT32      CountOfOwnedCriticalSections;
+        HANDLE64    CsrClientThread;
+        PVOID64     Win32ThreadInfo;
+        //rest of the structure is not defined for now, as it is not needed
+    }*PTEB64;
+    static_assert(offsetof(TEB64, ProcessEnvironmentBlock) == 0x0060);
+#pragma endregion
+
+
+#pragma region PEB
+    typedef struct LDR_DATA_TABLE_ENTRY64
+    {
+        LIST_ENTRY64    InLoadOrderLinks;
+        LIST_ENTRY64    InMemoryOrderLinks;
+        LIST_ENTRY64    InInitializationOrderLinks;
+
+        PVOID64         DllBase;
+        PVOID64         EntryPoint;
+        UINT32          SizeOfImage;
+
+        UNICODE_STRING64    FullDllName;
+        UNICODE_STRING64    BaseDllName;
+
+        union
+        {
+            UINT32      Flags;
+            struct
+            {
+                UINT32  PackagedBinary : 1;
+                UINT32  MarkedForRemoval : 1;
+                UINT32  ImageDll : 1;
+                UINT32  LoadNotificationsSent : 1;
+                UINT32  TelemetryEntryProcessed : 1;
+                UINT32  ProcessStaticImport : 1;
+                UINT32  InLegacyLists : 1;
+                UINT32  InIndexes : 1;
+                UINT32  ShimDll : 1;
+                UINT32  InExceptionTable : 1;
+                UINT32  ReservedFlags1 : 2;
+                UINT32  LoadInProgress : 1;
+                UINT32  LoadConfigProcessed : 1;
+                UINT32  EntryProcessed : 1;
+                UINT32  ProtectDelayLoad : 1;
+                UINT32  ReservedFlags3 : 2;
+                UINT32  DontCallForThreads : 1;
+                UINT32  ProcessAttachCalled : 1;
+                UINT32  ProcessAttachFailed : 1;
+                UINT32  CorDeferredValidate : 1;
+                UINT32  CorImage : 1;
+                UINT32  DontRelocate : 1;
+                UINT32  CorILOnly : 1;
+                UINT32  ReservedFlags5 : 3;
+                UINT32  Redirected : 1;
+                UINT32  ReservedFlags6 : 2;
+                UINT32  CompatDatabaseProcessed : 1;
+            };
+        };
+
+        UINT16          LoadCount;
+        UINT16          TlsIndex;
+
+        LIST_ENTRY64    HashLinks;
+
+        union
+        {
+            UINT32      TimeDateStamp;
+            PVOID64     LoadedImports;
+        };
+
+        PVOID64         EntryPointActivationContext;
+        HANDLE64        Lock;
+        PVOID64         DdagNode;
+        LIST_ENTRY64    NodeModuleLink;
+        PVOID64         LoadContext;
+        PVOID64         ParentDllBase;
+        PVOID64         SwitchBackContext;
+    }*PLDR_DATA_TABLE_ENTRY64;
+    static_assert(offsetof(LDR_DATA_TABLE_ENTRY64, DllBase      ) == 0x0030);
+    static_assert(offsetof(LDR_DATA_TABLE_ENTRY64, EntryPoint   ) == 0x0038);
+    static_assert(offsetof(LDR_DATA_TABLE_ENTRY64, FullDllName  ) == 0x0048);
+
+    typedef struct PEB_LDR_DATA64
+    {
+        UINT32          Length;
+        UINT8           Initialized;
+        HANDLE64        SsHandle;
+        LIST_ENTRY64    InLoadOrderModuleList;  // LDR_DATA_TABLE_ENTRY
+        LIST_ENTRY64    InMemoryOrderModuleList;
+        LIST_ENTRY64    InInitializationOrderModuleList;
+        PVOID64         EntryInProgress;
+        UINT8           ShutdownInProgress;
+        HANDLE64        ShutdownThreadId;
+    }*PPEB_LDR_DATA64;
+    static_assert(offsetof(PEB_LDR_DATA64, InLoadOrderModuleList) == 0x0010);
+
+    typedef struct RTL_USER_PROCESS_PARAMETERS64
+    {
+        DWORD       MaximumLength;
+        DWORD       Length;
+        DWORD       Flags;
+        DWORD       DebugFlags;
+        HANDLE64    ConsoleHandle;
+        DWORD       ConsoleFlags;
+        HANDLE64    StandardInput;
+        HANDLE64    StandardOutput;
+        HANDLE64    StandardError;
+        CURDIR64    CurrentDirectory;
+        UNICODE_STRING64 DllPath;
+        UNICODE_STRING64 ImagePathName;
+        UNICODE_STRING64 CommandLine;
+    }*PRTL_USER_PROCESS_PARAMETERS64;
+    static_assert(offsetof(RTL_USER_PROCESS_PARAMETERS64, DllPath) == 0x0050);
+
+    typedef struct PEB64
+    {
+        enum : UINT32
+        {
+            GdiHandleBufferSize32   = 34,
+            GdiHandleBufferSize64   = 60,
+            GdiHandleBufferSize     = (sizeof(SIZE_T) == sizeof(UINT32) ? GdiHandleBufferSize32 : GdiHandleBufferSize64),
+
+            FlsMaximumAvailable     = 128,
+            TlsMinimumAvailable     = 64,
+            TlsExpansionSlots       = 1024,
+        };
+
+        UINT8   InheritedAddressSpace;
+        UINT8   ReadImageFileExecOptions;
+        UINT8   BeingDebugged;
+        union
+        {
+            UINT8       BitField;
+            struct
+            {
+                UINT8   ImageUsesLargePages : 1;
+                UINT8   IsProtectedProcess : 1;
+                UINT8   IsImageDynamicallyRelocated : 1;
+                UINT8   SkipPatchingUser32Forwarders : 1;
+                UINT8   IsPackagedProcess : 1;
+                UINT8   IsAppContainer : 1;
+                UINT8   IsProtectedProcessLight : 1;
+                UINT8   IsLongPathAwareProcess : 1;
+            };
+        };
+        PVOID64     Mutant;
+        PVOID64     ImageBaseAddress;
+        PVOID64     Ldr;                                // PPEB_LDR_DATA64
+        PVOID64     ProcessParameters;                  // PRTL_USER_PROCESS_PARAMETERS64
+        PVOID64     SubSystemData;
+        HANDLE64    ProcessHeap;
+        HANDLE64    FastPebLock;
+        PVOID64     AtlThunkSListPtr;
+        PVOID64     IFEOKey;
+        union
+        {
+            UINT32      CrossProcessFlags;
+            struct
+            {
+                UINT32  ProcessInJob : 1;
+                UINT32  ProcessInitializing : 1;
+                UINT32  ProcessUsingVEH : 1;
+                UINT32  ProcessUsingVCH : 1;
+                UINT32  ProcessUsingFTH : 1;
+                UINT32  ProcessPreviouslyThrottled : 1;
+                UINT32  ProcessCurrentlyThrottled : 1;
+                UINT32  ReservedBits0 : 25;
+            };
+        };
+        union
+        {
+            PVOID64     KernelCallbackTable;
+            PVOID64     UserSharedInfoPtr;
+        };
+        UINT32          SystemReserved[1];
+        UINT32          AtlThunkSListPtr32;
+        PVOID64         ApiSetMap;
+        UINT32          TlsExpansionCounter;
+        PVOID64         TlsBitmap;
+        UINT32          TlsBitmapBits[2];
+        PVOID64         ReadOnlySharedMemoryBase;
+        PVOID64         HotpatchInformation;
+        PVOID64         ReadOnlyStaticServerData;
+        PVOID64         AnsiCodePageData;
+        PVOID64         OemCodePageData;
+        PVOID64         UnicodeCaseTableData;
+        UINT32          NumberOfProcessors;
+        UINT32          NtGlobalFlag;
+        LARGE_INTEGER   CriticalSectionTimeout;
+        UINT64          HeapSegmentReserve;             // SIZE_T
+        UINT64          HeapSegmentCommit;              // SIZE_T
+        UINT64          HeapDeCommitTotalFreeThreshold; // SIZE_T
+        UINT64          HeapDeCommitFreeBlockThreshold; // SIZE_T
+        UINT32          NumberOfHeaps;
+        UINT32          MaximumNumberOfHeaps;
+        PVOID64         ProcessHeaps;
+        PVOID64         GdiSharedHandleTable;
+        PVOID64         ProcessStarterHelper;
+        UINT32          GdiDCAttributeList;
+        PVOID64         LoaderLock;
+        UINT32          OSMajorVersion;
+        UINT32          OSMinorVersion;
+        UINT16          OSBuildNumber;
+        UINT16          OSCSDVersion;
+        UINT32          OSPlatformId;
+        UINT32          ImageSubsystem;
+        UINT32          ImageSubsystemMajorVersion;
+        UINT32          ImageSubsystemMinorVersion;
+        UINT64          ActiveProcessAffinityMask;      // SIZE_T
+        UINT32          GdiHandleBuffer[GdiHandleBufferSize];
+        PVOID64         PostProcessInitRoutine;
+        PVOID64         TlsExpansionBitmap;
+        UINT32          TlsExpansionBitmapBits[32];
+        UINT32          SessionId;
+        ULARGE_INTEGER  AppCompatFlags;
+        ULARGE_INTEGER  AppCompatFlagsUser;
+        PVOID64         pShimData;
+        PVOID64         AppCompatInfo;
+        UNICODE_STRING64 CSDVersion;
+        PVOID64         ActivationContextData;
+        PVOID64         ProcessAssemblyStorageMap;
+        PVOID64         SystemDefaultActivationContextData;
+        PVOID64         SystemAssemblyStorageMap;
+        UINT64          MinimumStackCommit;             // SIZE_T
+        PVOID64         FlsCallback;
+        LIST_ENTRY64    FlsListHead;
+        PVOID64         FlsBitmap;
+        UINT32          FlsBitmapBits[FlsMaximumAvailable / (sizeof(UINT32) * 8)];
+        UINT32          FlsHighIndex;
+        PVOID64         WerRegistrationData;
+        PVOID64         WerShipAssertPtr;
+        PVOID64         ContextData;
+        PVOID64         ImageHeaderHash;
+        union
+        {
+            UINT32      TracingFlags;
+            struct
+            {
+                UINT32  HeapTracingEnabled : 1;
+                UINT32  CritSecTracingEnabled : 1;
+                UINT32  LibLoaderTracingEnabled : 1;
+                UINT32  SpareTracingBits : 29;
+            };
+        };
+        UINT64          CsrServerReadOnlySharedMemoryBase;
+        PVOID64         TppWorkerpListLock;
+        LIST_ENTRY64    TppWorkerpList;
+        PVOID64         WaitOnAddressHashTable[128];
+        PVOID64         TelemetryCoverageHeader;        // REDSTONE3
+        UINT32          CloudFileFlags;
+        UINT32          CloudFileDiagFlags;             // REDSTONE4
+        UINT8           PlaceholderCompatibilityMode;
+        UINT8           PlaceholderCompatibilityModeReserved[7];
+    }*PPEB64;
+    static_assert(offsetof(PEB64, ImageBaseAddress  ) == 0x0010);
+    static_assert(offsetof(PEB64, Ldr               ) == 0x0018);
+    static_assert(offsetof(PEB64, ProcessParameters ) == 0x0020);
+#pragma endregion
+
+
+#pragma region Memory
+    enum MEMORY_INFORMATION_CLASS
+    {
+        MemoryBasicInformation,             // MEMORY_BASIC_INFORMATION
+        MemoryWorkingSetInformation,        // MEMORY_WORKING_SET_INFORMATION
+        MemoryMappedFilenameInformation,    // UNICODE_STRING
+        MemoryRegionInformation,            // MEMORY_REGION_INFORMATION
+        MemoryWorkingSetExInformation,      // MEMORY_WORKING_SET_EX_INFORMATION
+        MemorySharedCommitInformation,      // MEMORY_SHARED_COMMIT_INFORMATION
+        MemoryImageInformation,             // MEMORY_IMAGE_INFORMATION
+        MemoryRegionInformationEx,
+        MemoryPrivilegedBasicInformation,
+        MemoryEnclaveImageInformation,      // MEMORY_ENCLAVE_IMAGE_INFORMATION // since REDSTONE3
+        MemoryBasicInformationCapped
+    };
+#pragma endregion
+
+
+#pragma region Section
+    typedef enum SECTION_INHERIT
+    {
+        ViewShare = 1,
+        ViewUnmap = 2
+    }*PSECTION_INHERIT;
+#pragma endregion
+
+
+}
+#pragma warning(pop)
+
+using sdkext::PVOID;
+using sdkext::PVOID32;
+using sdkext::PVOID64;
+
+using sdkext::HANDLE;
+using sdkext::HANDLE32;
+using sdkext::HANDLE64;

--- a/XAntiDebug/wow64ext.cpp
+++ b/XAntiDebug/wow64ext.cpp
@@ -294,7 +294,7 @@ DWORD64 getTEB64()
     return reg.v;
 }
 
-DWORD64 __cdecl GetModuleHandle64(wchar_t* lpModuleName)
+DWORD64 __cdecl GetModuleHandle64(const wchar_t* lpModuleName)
 {
 	if (!g_isWow64)
 		return 0;
@@ -379,7 +379,7 @@ DWORD64 getLdrGetProcedureAddress()
     // lazy search, there is no need to use binsearch for just one function
     for (DWORD i = 0; i < ied.NumberOfFunctions; i++)
     {
-        if (!cmpMem64("LdrGetProcedureAddress", modBase + nameTable[i], sizeof("LdrGetProcedureAddress")))
+        if (!cmpMem64((void*)"LdrGetProcedureAddress", modBase + nameTable[i], sizeof("LdrGetProcedureAddress")))
             continue;
         else
             return modBase + rvaTable[ordTable[i]];
@@ -408,7 +408,7 @@ VOID __cdecl SetLastErrorFromX64Call(DWORD64 status)
 	}
 }
 
-DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, char* funcName)
+DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, const char* funcName)
 {
     static DWORD64 _LdrGetProcedureAddress = 0;
     if (0 == _LdrGetProcedureAddress)

--- a/XAntiDebug/wow64ext.cpp
+++ b/XAntiDebug/wow64ext.cpp
@@ -1,596 +1,1203 @@
-/**
- *
- * WOW64Ext Library
- *
- * Copyright (c) 2014 ReWolf
- * http://blog.rewolf.pl/
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+﻿/**
+*
+* WOW64Ext Library
+*
+* Copyright (c) 2014 ReWolf
+* http://blog.rewolf.pl/
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
 
-#include <Windows.h>
-#include <cstddef>
-#include "internal.h"
+
+#include <windows.h>
 #include "wow64ext.h"
-#include "CMemPtr.h"
+#include "_wow64ext.inl"
 
-HANDLE g_heap;
-BOOL g_isWow64;
+#ifndef STATUS_SUCCESS
+#   define STATUS_SUCCESS           ((NTSTATUS)0x00000000L)
+#endif
+#ifndef STATUS_NOT_SUPPORTED
+#   define STATUS_NOT_SUPPORTED     ((NTSTATUS)0xC00000BBL)
+#endif
 
-// void* malloc(size_t size)
-// {
-// 	return HeapAlloc(g_heap, 0, size);
-// }
-// 
-// void free(void* ptr)
-// {
-// 	if (nullptr != ptr)
-// 		HeapFree(g_heap, 0, ptr);
-// }
 
-// int _wcsicmp(const wchar_t *string1, const wchar_t *string2)
-// {
-// 	wchar_t c1;
-// 	wchar_t c2;
-// 	int i = 0;
-// 	do
-// 	{
-// 		c1 = string1[i];
-// 		if (c1 >= 'A' && c1 <= 'Z')
-// 			c1 += 0x20;
-// 
-// 		c2 = string2[i];
-// 		if (c2 >= 'A' && c2 <= 'Z')
-// 			c2 += 0x20;
-// 
-// 		i++;
-// 	} while (c1 && c1 == c2);
-// 	return c1 - c2;
-// }
-
-BOOL InitWow64Ext()
+void* __cdecl operator new[](size_t aSize)
 {
+    if (0 == aSize)
+        aSize = 1;
 
-	IsWow64Process(GetCurrentProcess(), &g_isWow64);
-	g_heap = GetProcessHeap();
-
-	return TRUE;
+    return HeapAlloc(GetProcessHeap(), HEAP_ZERO_MEMORY, aSize);
 }
 
-#pragma warning(push)
-#pragma warning(disable : 4409)
-DWORD64 __cdecl X64Call(DWORD64 func, int argC, ...)
+void __cdecl operator delete[](void* aPtr)
 {
-	if (!g_isWow64)
-		return 0;
-
-    va_list args;
-    va_start(args, argC);
-    reg64 _rcx = { (argC > 0) ? argC--, va_arg(args, DWORD64) : 0 };
-    reg64 _rdx = { (argC > 0) ? argC--, va_arg(args, DWORD64) : 0 };
-    reg64 _r8 = { (argC > 0) ? argC--, va_arg(args, DWORD64) : 0 };
-    reg64 _r9 = { (argC > 0) ? argC--, va_arg(args, DWORD64) : 0 };
-    reg64 _rax = { 0 };
-
-    reg64 restArgs = { (DWORD64)&va_arg(args, DWORD64) };
-    
-    // conversion to QWORD for easier use in inline assembly
-    reg64 _argC = { (DWORD64)argC };
-    DWORD back_esp = 0;
-	WORD back_fs = 0;
-
-    __asm
-    {
-        ;// reset FS segment, to properly handle RFG
-        mov    back_fs, fs
-        mov    eax, 0x2B
-        mov    fs, ax
-
-        ;// keep original esp in back_esp variable
-        mov    back_esp, esp
-        
-        ;// align esp to 0x10, without aligned stack some syscalls may return errors !
-        ;// (actually, for syscalls it is sufficient to align to 8, but SSE opcodes 
-        ;// requires 0x10 alignment), it will be further adjusted according to the
-        ;// number of arguments above 4
-        and    esp, 0xFFFFFFF0
-
-        X64_Start();
-
-        ;// below code is compiled as x86 inline asm, but it is executed as x64 code
-        ;// that's why it need sometimes REX_W() macro, right column contains detailed
-        ;// transcription how it will be interpreted by CPU
-
-        ;// fill first four arguments
-  REX_W mov    ecx, _rcx.dw[0]                          ;// mov     rcx, qword ptr [_rcx]
-  REX_W mov    edx, _rdx.dw[0]                          ;// mov     rdx, qword ptr [_rdx]
-        push   _r8.v                                    ;// push    qword ptr [_r8]
-        X64_Pop(_R8);                                   ;// pop     r8
-        push   _r9.v                                    ;// push    qword ptr [_r9]
-        X64_Pop(_R9);                                   ;// pop     r9
-                                                        ;//
-  REX_W mov    eax, _argC.dw[0]                         ;// mov     rax, qword ptr [_argC]
-                                                        ;// 
-        ;// final stack adjustment, according to the    ;//
-        ;// number of arguments above 4                 ;// 
-        test   al, 1                                    ;// test    al, 1
-        jnz    _no_adjust                               ;// jnz     _no_adjust
-        sub    esp, 8                                   ;// sub     rsp, 8
-_no_adjust:                                             ;//
-                                                        ;// 
-        push   edi                                      ;// push    rdi
-  REX_W mov    edi, restArgs.dw[0]                      ;// mov     rdi, qword ptr [restArgs]
-                                                        ;// 
-        ;// put rest of arguments on the stack          ;// 
-  REX_W test   eax, eax                                 ;// test    rax, rax
-        jz     _ls_e                                    ;// je      _ls_e
-  REX_W lea    edi, dword ptr [edi + 8*eax - 8]         ;// lea     rdi, [rdi + rax*8 - 8]
-                                                        ;// 
-_ls:                                                    ;// 
-  REX_W test   eax, eax                                 ;// test    rax, rax
-        jz     _ls_e                                    ;// je      _ls_e
-        push   dword ptr [edi]                          ;// push    qword ptr [rdi]
-  REX_W sub    edi, 8                                   ;// sub     rdi, 8
-  REX_W sub    eax, 1                                   ;// sub     rax, 1
-        jmp    _ls                                      ;// jmp     _ls
-_ls_e:                                                  ;// 
-                                                        ;// 
-        ;// create stack space for spilling registers   ;// 
-  REX_W sub    esp, 0x20                                ;// sub     rsp, 20h
-                                                        ;// 
-        call   func                                     ;// call    qword ptr [func]
-                                                        ;// 
-        ;// cleanup stack                               ;// 
-  REX_W mov    ecx, _argC.dw[0]                         ;// mov     rcx, qword ptr [_argC]
-  REX_W lea    esp, dword ptr [esp + 8*ecx + 0x20]      ;// lea     rsp, [rsp + rcx*8 + 20h]
-                                                        ;// 
-        pop    edi                                      ;// pop     rdi
-                                                        ;// 
-        // set return value                             ;// 
-  REX_W mov    _rax.dw[0], eax                          ;// mov     qword ptr [_rax], rax
-
-        X64_End();
-
-        mov    ax, ds
-        mov    ss, ax
-        mov    esp, back_esp
-
-        ;// restore FS segment
-        mov    ax, back_fs
-        mov    fs, ax
-    }
-    return _rax.v;
-}
-#pragma warning(pop)
-
-void getMem64(void* dstMem, DWORD64 srcMem, size_t sz)
-{
-    if ((nullptr == dstMem) || (0 == srcMem) || (0 == sz))
+    if (nullptr == aPtr)
         return;
 
-    reg64 _src = { srcMem };
-
-    __asm
-    {
-        X64_Start();
-
-        ;// below code is compiled as x86 inline asm, but it is executed as x64 code
-        ;// that's why it need sometimes REX_W() macro, right column contains detailed
-        ;// transcription how it will be interpreted by CPU
-
-        push   edi                  ;// push     rdi
-        push   esi                  ;// push     rsi
-                                    ;//
-        mov    edi, dstMem          ;// mov      edi, dword ptr [dstMem]        ; high part of RDI is zeroed
-  REX_W mov    esi, _src.dw[0]      ;// mov      rsi, qword ptr [_src]
-        mov    ecx, sz              ;// mov      ecx, dword ptr [sz]            ; high part of RCX is zeroed
-                                    ;//
-        mov    eax, ecx             ;// mov      eax, ecx
-        and    eax, 3               ;// and      eax, 3
-        shr    ecx, 2               ;// shr      ecx, 2
-                                    ;//
-        rep    movsd                ;// rep movs dword ptr [rdi], dword ptr [rsi]
-                                    ;//
-        test   eax, eax             ;// test     eax, eax
-        je     _move_0              ;// je       _move_0
-        cmp    eax, 1               ;// cmp      eax, 1
-        je     _move_1              ;// je       _move_1
-                                    ;//
-        movsw                       ;// movs     word ptr [rdi], word ptr [rsi]
-        cmp    eax, 2               ;// cmp      eax, 2
-        je     _move_0              ;// je       _move_0
-                                    ;//
-_move_1:                            ;//
-        movsb                       ;// movs     byte ptr [rdi], byte ptr [rsi]
-                                    ;//
-_move_0:                            ;//
-        pop    esi                  ;// pop      rsi
-        pop    edi                  ;// pop      rdi
-
-        X64_End();
-    }
+    HeapFree(GetProcessHeap(), 0, aPtr);
 }
 
-bool cmpMem64(void* dstMem, DWORD64 srcMem, size_t sz)
+
+namespace wow64ext
 {
-    if ((nullptr == dstMem) || (0 == srcMem) || (0 == sz))
-        return false;
 
-    bool result = false;
-    reg64 _src = { srcMem };
-    __asm
+    static auto IsWow64Mode()
+        -> bool
     {
-        X64_Start();
+        auto vWow64Mode = FALSE;
+        return (IsWow64Process(GetCurrentProcess(), &vWow64Mode) && !!vWow64Mode);
+    }
+    bool Wow64Mode = IsWow64Mode();
 
-        ;// below code is compiled as x86 inline asm, but it is executed as x64 code
-        ;// that's why it need sometimes REX_W() macro, right column contains detailed
-        ;// transcription how it will be interpreted by CPU
+    wow64ext_pub auto wow64ext_api Wow64CopyMemory64(
+        _Out_bytecap_(aBytes)   PVOID64 aDst,
+        _In_bytecount_(aBytes)  PVOID64 aSrc,
+        _In_                    UINT64  aBytes
+    ) -> VOID
+    {
+        if (!Wow64Mode)
+        {
+            return;
+        }
+        
+        if (nullptr == aDst ||
+            nullptr == aSrc ||
+            0       == aBytes)
+        {
+            return;
+        }
 
-        push   edi                  ;// push      rdi
-        push   esi                  ;// push      rsi
-                                    ;//           
-        mov    edi, dstMem          ;// mov       edi, dword ptr [dstMem]       ; high part of RDI is zeroed
-  REX_W mov    esi, _src.dw[0]      ;// mov       rsi, qword ptr [_src]
-        mov    ecx, sz              ;// mov       ecx, dword ptr [sz]           ; high part of RCX is zeroed
-                                    ;//           
-        mov    eax, ecx             ;// mov       eax, ecx
-        and    eax, 3               ;// and       eax, 3
-        shr    ecx, 2               ;// shr       ecx, 2
-                                    ;// 
-        repe   cmpsd                ;// repe cmps dword ptr [rsi], dword ptr [rdi]
-        jnz     _ret_false          ;// jnz       _ret_false
-                                    ;// 
-        test   eax, eax             ;// test      eax, eax
-        je     _move_0              ;// je        _move_0
-        cmp    eax, 1               ;// cmp       eax, 1
-        je     _move_1              ;// je        _move_1
-                                    ;// 
-        cmpsw                       ;// cmps      word ptr [rsi], word ptr [rdi]
-        jnz     _ret_false          ;// jnz       _ret_false
-        cmp    eax, 2               ;// cmp       eax, 2
-        je     _move_0              ;// je        _move_0
-                                    ;// 
-_move_1:                            ;// 
-        cmpsb                       ;// cmps      byte ptr [rsi], byte ptr [rdi]
-        jnz     _ret_false          ;// jnz       _ret_false
-                                    ;// 
-_move_0:                            ;// 
-        mov    result, 1            ;// mov       byte ptr [result], 1
-                                    ;// 
-_ret_false:                         ;// 
-        pop    esi                  ;// pop      rsi
-        pop    edi                  ;// pop      rdi
+        Reg64 vDst      = { (UINT64)aDst    };
+        Reg64 vSrc      = { (UINT64)aSrc    };
+        Reg64 vBytes    = { (UINT64)aBytes  };
 
-        X64_End();
+        __asm
+        {
+            X64Start();
+
+            ;// below code is compiled as x86 inline asm, but it is executed as x64 code
+            ;// that's why it need sometimes REX_W() macro, right column contains detailed
+            ;// transcription how it will be interpreted by CPU
+
+            push   edi                      ;// push     rdi
+            push   esi                      ;// push     rsi
+                                            ;//
+      REX_W mov    edi, vDst.dw[0]          ;// mov      rdi, dword ptr [vDst]
+      REX_W mov    esi, vSrc.dw[0]          ;// mov      rsi, qword ptr [vSrc]
+      REX_W mov    ecx, vBytes.dw[0]        ;// mov      ecx, dword ptr [vBytes]
+                                            ;//
+      REX_W mov    eax, ecx                 ;// mov      rax, rcx
+      REX_W and    eax, 3                   ;// and      rax, 3
+      REX_W shr    ecx, 2                   ;// shr      rcx, 2
+                                            ;//
+            rep    movsd                    ;// rep movs dword ptr [rdi], dword ptr [rsi]
+                                            ;//
+      REX_W test   eax, eax                 ;// test     rax, rax
+            je     _move_0                  ;// je       _move_0
+      REX_W cmp    eax, 1                   ;// cmp      rax, 1
+            je     _move_1                  ;// je       _move_1
+                                            ;//
+            movsw                           ;// movs     word ptr [rdi], word ptr [rsi]
+      REX_W cmp    eax, 2                   ;// cmp      eax, 2
+            je     _move_0                  ;// je       _move_0
+                                            ;//
+        _move_1:                            ;//
+            movsb                           ;// movs     byte ptr [rdi], byte ptr [rsi]
+                                            ;//
+        _move_0:                            ;//
+            pop    esi                      ;// pop      rsi
+            pop    edi                      ;// pop      rdi
+
+            X64End();
+        }
     }
 
-    return result;
-}
+    wow64ext_pub auto wow64ext_api Wow64CompareMemory64(
+        _In_bytecount_(aBytes)  PVOID64 aBuffer1,
+        _In_bytecount_(aBytes)  PVOID64 aBuffer2,
+        _In_                    UINT64  aBytes
+    )->bool
+    {
+        if (!Wow64Mode)
+        {
+            return false;
+        }
 
-DWORD64 getTEB64()
-{
-    reg64 reg;
-    reg.v = 0;
+        if (nullptr == aBuffer1 ||
+            nullptr == aBuffer2 ||
+            0       == aBytes)
+        {
+            return false;
+        }
+
+        bool  vResult   = false;
+        Reg64 vBuffer1  = { (UINT64)aBuffer1 };
+        Reg64 vBuffer2  = { (UINT64)aBuffer2 };
+        Reg64 vBytes    = { (UINT64)aBytes   };
+        
+        __asm
+        {
+            X64Start();
+
+            ;// below code is compiled as x86 inline asm, but it is executed as x64 code
+            ;// that's why it need sometimes REX_W() macro, right column contains detailed
+            ;// transcription how it will be interpreted by CPU
+
+            push   edi                      ;// push      rdi
+            push   esi                      ;// push      rsi
+                                            ;//           
+      REX_W mov    edi, vBuffer1.dw[0]      ;// mov       rdi, dword ptr [vSource1]
+      REX_W mov    esi, vBuffer2.dw[0]      ;// mov       rsi, qword ptr [vSource2]
+      REX_W mov    ecx, vBytes.dw[0]        ;// mov       ecx, dword ptr [vLength]
+                                            ;//           
+      REX_W mov    eax, ecx                 ;// mov       rax, rcx
+      REX_W and    eax, 3                   ;// and       rax, 3
+      REX_W shr    ecx, 2                   ;// shr       rcx, 2
+                                            ;// 
+            repe   cmpsd                    ;// repe cmps dword ptr [rsi], dword ptr [rdi]
+            jnz    _ret_false               ;// jnz       _ret_false
+                                            ;// 
+      REX_W test   eax, eax                 ;// test      rax, rax
+            je     _move_0                  ;// je        _move_0
+      REX_W cmp    eax, 1                   ;// cmp       rax, 1
+            je     _move_1                  ;// je        _move_1
+                                            ;// 
+            cmpsw                           ;// cmps      word ptr [rsi], word ptr [rdi]
+            jnz    _ret_false               ;// jnz       _ret_false
+      REX_W cmp    eax, 2                   ;// cmp       rax, 2
+            je     _move_0                  ;// je        _move_0
+                                            ;// 
+        _move_1:                            ;// 
+            cmpsb                           ;// cmps      byte ptr [rsi], byte ptr [rdi]
+            jnz    _ret_false               ;// jnz       _ret_false
+                                            ;// 
+        _move_0:                            ;// 
+            mov    vResult, 1               ;// mov       byte ptr [result], 1
+                                            ;// 
+        _ret_false:                         ;// 
+            pop    esi                      ;// pop      rsi
+            pop    edi                      ;// pop      rdi
+
+            X64End();
+        }
+
+        return vResult;
+    }
+
+    wow64ext_pub auto wow64ext_api Wow64Call64(
+        _In_                    PVOID64 aFunc,
+        _In_                    int     aArgsCount,
+        _In_opt_                ...     /*Args*/
+    )->UINT64
+    {
+        if (!Wow64Mode)
+        {
+            return (UINT64)0xC00000BBL; /*STATUS_NOT_SUPPORTED*/
+        }
+
+        va_list vArgs;
+        va_start(vArgs, aArgsCount);
+
+        Reg64 vRcx  = { (aArgsCount > 0) ? aArgsCount--, va_arg(vArgs, UINT64) : 0 };
+        Reg64 vRdx  = { (aArgsCount > 0) ? aArgsCount--, va_arg(vArgs, UINT64) : 0 };
+        Reg64 vR8   = { (aArgsCount > 0) ? aArgsCount--, va_arg(vArgs, UINT64) : 0 };
+        Reg64 vR9   = { (aArgsCount > 0) ? aArgsCount--, va_arg(vArgs, UINT64) : 0 };
+        Reg64 vRax  = { 0 };
+
+        Reg64 vFunc         = { (UINT64)aFunc };
+        Reg64 vRestArgs     = { (UINT64)(PVOID64)&va_arg(vArgs, UINT64) };
+        Reg64 vArgsCount    = { (UINT64)aArgsCount };
+        
+        UINT32 vBackEsp = 0;
+        UINT16 vBackFs  = 0;
+
+        __asm
+        {
+
+            ;// reset FS segment, to properly handle RFG
+            mov    vBackFs, fs;
+            mov    eax, 0x2B;
+            mov    fs, ax;
+
+            ;// keep original esp in vBackEsp variable
+            mov    vBackEsp, esp;
+
+            ;// align esp to 0x10, without aligned stack some syscalls may return errors !
+            ;// (actually, for syscalls it is sufficient to align to 8, but SSE opcodes 
+            ;// requires 0x10 alignment), it will be further adjusted according to the
+            ;// number of arguments above 4
+            and    esp, 0xFFFFFFF0;
+
+            X64Start();
+
+            ;// below code is compiled as x86 inline asm, but it is executed as x64 code
+            ;// that's why it need sometimes REX_W() macro, right column contains detailed
+            ;// transcription how it will be interpreted by CPU
+
+            ;// fill first four arguments
+      REX_W mov    ecx, vRcx.dw[0]              ;// mov     rcx, qword ptr [vRcx]
+      REX_W mov    edx, vRdx.dw[0]              ;// mov     rdx, qword ptr [vRdx]
+            push   vR8.dw[0]                    ;// push    qword ptr [vR8]
+            X64Pop(_R8)                         ;// pop     r8
+            push   vR9.dw[0]                    ;// push    qword ptr [vR9]
+            X64Pop(_R9)                         ;// pop     r9
+                                                ;//
+      REX_W mov    eax, vArgsCount.dw[0]        ;// mov     rax, qword ptr [vArgsCount]
+                                                ;// 
+                                                ;// final stack adjustment, according to the    ;//
+                                                ;// number of arguments above 4                 ;// 
+            test   al, 1                        ;// test    al, 1
+            jnz    _no_adjust                   ;// jnz     _no_adjust
+            sub    esp, 8                       ;// sub     rsp, 8
+        _no_adjust:                             ;//
+                                                ;// 
+            push   edi                          ;// push    rdi
+      REX_W mov    edi, vRestArgs.dw[0]         ;// mov     rdi, qword ptr [vRestArgs]
+                                                ;// 
+                                                ;// put rest of arguments on the stack          ;// 
+      REX_W test   eax, eax                     ;// test    rax, rax
+            jz     _ls_e                        ;// je      _ls_e
+      REX_W lea    edi, dword ptr[edi + 8 * eax - 8];// lea     rdi, [rdi + rax*8 - 8]
+                                                ;// 
+        _ls:                                    ;// 
+      REX_W test   eax, eax                     ;// test    rax, rax
+            jz     _ls_e                        ;// je      _ls_e
+            push   dword ptr[edi]               ;// push    qword ptr [rdi]
+      REX_W sub    edi, 8                       ;// sub     rdi, 8
+      REX_W sub    eax, 1                       ;// sub     rax, 1
+            jmp    _ls                          ;// jmp     _ls
+        _ls_e:                                  ;// 
+                                                ;// 
+                                                ;// create stack space for spilling registers   ;// 
+            REX_W sub    esp, 0x20              ;// sub     rsp, 20h
+                                                ;// 
+            #pragma warning(suppress: 4409)
+            call   aFunc                        ;// call    qword ptr [func]
+                                                ;// 
+            ;// cleanup stack                   ;// 
+      REX_W mov    ecx, vArgsCount.dw[0]        ;// mov     rcx, qword ptr [vArgsCount]
+      REX_W lea    esp, dword ptr[esp + 8 * ecx + 0x20];// lea     rsp, [rsp + rcx*8 + 20h]
+                                                ;// 
+            pop    edi                          ;// pop     rdi
+                                                ;// 
+            ;// set return value                ;// 
+      REX_W mov    vRax.dw[0], eax              ;// mov     qword ptr [vRax], rax
+
+            X64End();
+
+            mov    ax, ds;
+            mov    ss, ax;
+            mov    esp, vBackEsp;
+
+            ;// restore FS segment
+            mov    ax, vBackFs;
+            mov    fs, ax;
+        }
+
+        return vRax.v;
+    }
+
+    wow64ext_pub auto wow64ext_api ZwWow64CurrentTeb64(
+    )->PVOID64 /*TEB64*/
+    {
+        if (!Wow64Mode)
+        {
+            return nullptr;
+        }
+
+        Reg64 vTeb64{};
+
+        // R12 register should always contain pointer to TEB64 in WoW64 processes
+        // below pop will pop QWORD from stack, as we're in x64 mode now
+
+        X64Start();
+        X64Push(_R12);
+        __asm pop vTeb64.dw[0];
+        X64End();
+
+        return (PVOID64)vTeb64.v;
+    }
+
+    wow64ext_pub auto wow64ext_api ZwWow64CurrentPeb64(
+    )->PVOID64 /*PEB64*/
+    {
+        if (!Wow64Mode)
+        {
+            return nullptr;
+        }
+
+        auto vTeb = TEB64();
+        Wow64CopyMemory64(&vTeb, ZwWow64CurrentTeb64(), sizeof(vTeb));
+
+        return vTeb.ProcessEnvironmentBlock;
+    }
+
+    wow64ext_pub auto wow64ext_api Wow64GetModuleHandle64(
+        _In_                    LPCWSTR aModuleName
+    )->PVOID64
+    {
+        if (!Wow64Mode)
+        {
+            return nullptr;
+        }
+
+        PEB64 vPeb{};
+        Wow64CopyMemory64(&vPeb, ZwWow64CurrentPeb64(), sizeof(vPeb));
+
+        PEB_LDR_DATA64 vLdr{};
+        Wow64CopyMemory64(&vLdr, vPeb.Ldr, sizeof(vLdr));
+
+        LDR_DATA_TABLE_ENTRY64 vEntry{};
+        vEntry.InLoadOrderLinks.Flink = vLdr.InLoadOrderModuleList.Flink;
+        auto vEndEntry = (PVOID64)((UINT64)vPeb.Ldr + offsetof(PEB_LDR_DATA64, InLoadOrderModuleList));
+
+        PVOID64 vDllBase = nullptr;
+        do
+        {
+            Wow64CopyMemory64(&vEntry, vEntry.InLoadOrderLinks.Flink, sizeof(LDR_DATA_TABLE_ENTRY64));
+
+            auto vDllName = (wchar_t*)new UINT8[vEntry.BaseDllName.MaximumLength + sizeof(UNICODE_NULL)]{};
+            if (nullptr == vDllName)
+            {
+                break;
+            }
+            Wow64CopyMemory64(vDllName, vEntry.BaseDllName.Buffer, vEntry.BaseDllName.Length);
+
+            if (0 == _wcsicmp(aModuleName, vDllName))
+            {
+                delete[](UINT8*)vDllName, vDllName = nullptr;
+
+                vDllBase = vEntry.DllBase;
+                break;
+            }
+            delete[](UINT8*)vDllName, vDllName = nullptr;
+
+        } while (vEntry.InLoadOrderLinks.Flink != vEndEntry);
+
+        return vDllBase;
+    }
+
+    wow64ext_pub auto wow64ext_api Wow64GetNtdll64(
+    )->PVOID64
+    {
+        static PVOID64 sNtdll64 = nullptr;
+        if (sNtdll64) 
+        {
+            return sNtdll64;
+        }
+
+        sNtdll64 = Wow64GetModuleHandle64(L"ntdll.dll");
+        return sNtdll64;
+    }
+
+    wow64ext_pub auto wow64ext_api Wow64GetLdrGetProcedureAddress64(
+    )->PVOID64
+    {
+        static PVOID64 sLdrGetProcedureAddress64 = nullptr;
+        if (sLdrGetProcedureAddress64)
+        {
+            return sLdrGetProcedureAddress64;
+        }
+
+        UINT32* vAddressRvaArray    = nullptr;
+        UINT32* vNameRvaArray       = nullptr;
+        UINT16* vOrdinalsArray      = nullptr;
+        for (;;)
+        {
+            PVOID64 vDllBase = Wow64GetNtdll64();
+            if (nullptr == vDllBase)
+            {
+                break;
+            }
+
+            IMAGE_DOS_HEADER vDosHeader{};
+            Wow64CopyMemory64(&vDosHeader, vDllBase, sizeof(vDosHeader));
+
+            IMAGE_NT_HEADERS64 vNtHeader{};
+            Wow64CopyMemory64(
+                &vNtHeader,
+                (PVOID64)((UINT64)vDllBase + vDosHeader.e_lfanew),
+                sizeof(vNtHeader));
+
+            auto& vExportDataDirectory = vNtHeader.OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
+            if (0 == vExportDataDirectory.VirtualAddress)
+            {
+                break;
+            }
+
+            IMAGE_EXPORT_DIRECTORY vExportDirectory{};
+            Wow64CopyMemory64(&vExportDirectory, (PVOID64)((UINT64)vDllBase + vExportDataDirectory.VirtualAddress), sizeof(vExportDirectory));
+
+            vAddressRvaArray = new UINT32[vExportDirectory.NumberOfFunctions]{};
+            if (nullptr == vAddressRvaArray)
+            {
+                break;
+            }
+            Wow64CopyMemory64(vAddressRvaArray, (PVOID64)((UINT64)vDllBase + vExportDirectory.AddressOfFunctions), sizeof(UINT32) * (UINT64)vExportDirectory.NumberOfFunctions);
+
+            vNameRvaArray = new UINT32[vExportDirectory.NumberOfNames]{};
+            if (nullptr == vNameRvaArray)
+            {
+                break;
+            }
+            Wow64CopyMemory64(vNameRvaArray, (PVOID64)((UINT64)vDllBase + vExportDirectory.AddressOfNames), sizeof(UINT32) * (UINT64)vExportDirectory.NumberOfNames);
+
+            vOrdinalsArray = new UINT16[vExportDirectory.NumberOfFunctions]{};
+            if (nullptr == vOrdinalsArray)
+            {
+                break;
+            }
+            Wow64CopyMemory64(vOrdinalsArray, (PVOID64)((UINT64)vDllBase + vExportDirectory.AddressOfNameOrdinals), sizeof(UINT16) * (UINT64)vExportDirectory.NumberOfFunctions);
+
+            for (auto i = 0u; i < vExportDirectory.NumberOfNames; ++i)
+            {
+                if (Wow64CompareMemory64(
+                    (PVOID64)"LdrGetProcedureAddress",
+                    (PVOID64)((UINT64)vDllBase + vNameRvaArray[i]),
+                    sizeof("LdrGetProcedureAddress")))
+                {
+                    sLdrGetProcedureAddress64 = (PVOID64)((UINT64)vDllBase + vAddressRvaArray[vOrdinalsArray[i]]);
+                    break;
+                }
+            }
+
+            break;
+        }
+        delete[] vAddressRvaArray   , vAddressRvaArray  = nullptr;
+        delete[] vNameRvaArray      , vNameRvaArray     = nullptr;
+        delete[] vOrdinalsArray     , vOrdinalsArray    = nullptr;
+
+        return sLdrGetProcedureAddress64;
+    }
+
+    wow64ext_pub auto wow64ext_api Wow64GetProcAddress64(
+        _In_                    PVOID64 aModule,
+        _In_                    LPCSTR  aProcName
+    )->PVOID64
+    {
+        if (nullptr == aModule)
+        {
+            return nullptr;
+        }
+
+        PVOID64 vLdrGetProcedureAddress = Wow64GetLdrGetProcedureAddress64();
+        if (nullptr == vLdrGetProcedureAddress)
+        {
+            return nullptr;
+        }
+
+        ANSI_STRING64 vRoutineName{};
+        vRoutineName.Buffer = const_cast<LPSTR>(aProcName);
+        vRoutineName.Length = (UINT16)(sizeof(char) * strlen(aProcName));
+        vRoutineName.MaximumLength = (UINT16)(vRoutineName.Length + sizeof(ANSI_NULL));
+
+        PVOID64 vRoutine = nullptr;
+        auto vStatus = Wow64Call64(vLdrGetProcedureAddress, 4,
+            (UINT64)aModule,
+            (UINT64)&vRoutineName,
+            (UINT64)0,
+            (UINT64)&vRoutine);
+
+        return Wow64SetLastErrorFromNtStatus((NTSTATUS)vStatus), vRoutine;
+    }
+
+    wow64ext_pub auto wow64ext_api Wow64SetLastErrorFromNtStatus(
+        NTSTATUS    aStatus
+    )->NTSTATUS
+    {
+        using $RtlSetLastWin32ErrorAndNtStatusFromNtStatus          = void(WINAPI*)(NTSTATUS);
+        static auto sRtlSetLastWin32ErrorAndNtStatusFromNtStatus    = ($RtlSetLastWin32ErrorAndNtStatusFromNtStatus)nullptr;
+
+        if (sRtlSetLastWin32ErrorAndNtStatusFromNtStatus)
+        {
+            return sRtlSetLastWin32ErrorAndNtStatusFromNtStatus(aStatus), aStatus;
+        }
+
+        auto vModule = GetModuleHandleA("ntdll.dll");
+        if (nullptr == vModule)
+        {
+            return aStatus;
+        }
+
+        sRtlSetLastWin32ErrorAndNtStatusFromNtStatus = ($RtlSetLastWin32ErrorAndNtStatusFromNtStatus)GetProcAddress(
+            vModule, "RtlSetLastWin32ErrorAndNtStatusFromNtStatus");
+        if (nullptr == sRtlSetLastWin32ErrorAndNtStatusFromNtStatus)
+        {
+            return aStatus;
+        }
+
+        return sRtlSetLastWin32ErrorAndNtStatusFromNtStatus(aStatus), aStatus;
+    }
     
-    X64_Start();
-    // R12 register should always contain pointer to TEB64 in WoW64 processes
-    X64_Push(_R12);
-    // below pop will pop QWORD from stack, as we're in x64 mode now
-    __asm pop reg.dw[0]
-    X64_End();
-
-    return reg.v;
 }
 
-DWORD64 __cdecl GetModuleHandle64(const wchar_t* lpModuleName)
+namespace wow64ext
 {
-	if (!g_isWow64)
-		return 0;
 
-    TEB64 teb64;
-    getMem64(&teb64, getTEB64(), sizeof(TEB64));
-    
-    PEB64 peb64;
-    getMem64(&peb64, teb64.ProcessEnvironmentBlock, sizeof(PEB64));
-    PEB_LDR_DATA64 ldr;
-    getMem64(&ldr, peb64.Ldr, sizeof(PEB_LDR_DATA64));
-
-    DWORD64 LastEntry = peb64.Ldr + offsetof(PEB_LDR_DATA64, InLoadOrderModuleList);
-    LDR_DATA_TABLE_ENTRY64 head;
-    head.InLoadOrderLinks.Flink = ldr.InLoadOrderModuleList.Flink;
-    do
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64QueryVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_                PVOID64     aBaseAddress,
+        _In_ MEMORY_INFORMATION_CLASS   aMemoryInformationClass,
+        _Out_writes_bytes_(aMemoryInformationBytes) PVOID aMemoryInformation,
+        _In_                UINT64      aMemoryInformationBytes,
+        _Out_opt_           PUINT64     aReturnLength
+    )
     {
-        getMem64(&head, head.InLoadOrderLinks.Flink, sizeof(LDR_DATA_TABLE_ENTRY64));
+        NTSTATUS vStatus = STATUS_SUCCESS;
 
-        wchar_t* tempBuf = (wchar_t*)malloc(head.BaseDllName.MaximumLength);
-        if (nullptr == tempBuf)
+        for (;;)
+        {
+            if (nullptr == aBaseAddress)
+            {
+                vStatus = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            PVOID64 sNtQueryVirtualMemory = nullptr;
+            if (nullptr == sNtQueryVirtualMemory)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtQueryVirtualMemory = Wow64GetProcAddress64(vModule, "NtQueryVirtualMemory");
+                if (nullptr == sNtQueryVirtualMemory)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtQueryVirtualMemory, 6,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress,
+                (UINT64)aMemoryInformationClass,
+                (UINT64)aMemoryInformation,
+                (UINT64)aMemoryInformationBytes,
+                (UINT64)aReturnLength);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64AllocateVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_bytecount_(*aRegionSize) PVOID64* aBaseAddress,
+        _In_                UINT64      aZeroBits,
+        _Inout_             PUINT64     aRegionSize,
+        _In_                UINT32      aAllocationType,
+        _In_                UINT32      aProtect
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            if (nullptr == aBaseAddress)
+            {
+                vStatus = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            PVOID64 sNtAllocateVirtualMemory = nullptr;
+            if (nullptr == sNtAllocateVirtualMemory)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtAllocateVirtualMemory = Wow64GetProcAddress64(vModule, "NtAllocateVirtualMemory");
+                if (nullptr == sNtAllocateVirtualMemory)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtAllocateVirtualMemory, 6,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress,
+                (UINT64)aZeroBits,
+                (UINT64)aRegionSize,
+                (UINT64)aAllocationType,
+                (UINT64)aProtect);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64FreeVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _Inout_             PVOID64*    aBaseAddress,
+        _Inout_             PUINT64     aRegionSize,
+        _In_                UINT32      aFreeType
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            if (nullptr == aBaseAddress)
+            {
+                vStatus = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            PVOID64 sNtFreeVirtualMemory = nullptr;
+            if (nullptr == sNtFreeVirtualMemory)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtFreeVirtualMemory = Wow64GetProcAddress64(vModule, "NtFreeVirtualMemory");
+                if (nullptr == sNtFreeVirtualMemory)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtFreeVirtualMemory, 4,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress,
+                (UINT64)aRegionSize,
+                (UINT64)aFreeType);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64ProtectVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _Inout_             PVOID64 *   aBaseAddress,
+        _Inout_             PUINT64     aRegionSize,
+        _In_                UINT32      aNewProtect,
+        _Out_               PUINT32     aOldProtect
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            if (nullptr == aBaseAddress)
+            {
+                vStatus = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            PVOID64 sNtProtectVirtualMemory = nullptr;
+            if (nullptr == sNtProtectVirtualMemory)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtProtectVirtualMemory = Wow64GetProcAddress64(vModule, "NtProtectVirtualMemory");
+                if (nullptr == sNtProtectVirtualMemory)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtProtectVirtualMemory, 5,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress,
+                (UINT64)aRegionSize,
+                (UINT64)aNewProtect,
+                (UINT64)aOldProtect);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64ReadVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_opt_            PVOID64     aBaseAddress,
+        _Out_writes_bytes_(aBufferSize) PVOID aBuffer,
+        _In_                UINT64      aBufferSize,
+        _Out_opt_           PUINT64     aNumberOfBytesRead
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            if (aNumberOfBytesRead) *aNumberOfBytesRead = 0;
+
+            if (nullptr == aBaseAddress)
+            {
+                vStatus = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            PVOID64 sNtReadVirtualMemory = nullptr;
+            if (nullptr == sNtReadVirtualMemory)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtReadVirtualMemory = Wow64GetProcAddress64(vModule, "NtReadVirtualMemory");
+                if (nullptr == sNtReadVirtualMemory)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtReadVirtualMemory, 5,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress,
+                (UINT64)aBuffer,
+                (UINT64)aBufferSize,
+                (UINT64)aNumberOfBytesRead);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64WriteVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_opt_            PVOID64     aBaseAddress,
+        _In_reads_bytes_(aBufferSize)   PVOID aBuffer,
+        _In_                UINT64      aBufferSize,
+        _Out_opt_           PUINT64     aNumberOfBytesWritten
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            if(aNumberOfBytesWritten) *aNumberOfBytesWritten = 0;
+
+            if (nullptr == aBaseAddress)
+            {
+                vStatus = STATUS_INVALID_PARAMETER;
+                break;
+            }
+
+            PVOID64 sNtWriteVirtualMemory = nullptr;
+            if (nullptr == sNtWriteVirtualMemory)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtWriteVirtualMemory = Wow64GetProcAddress64(vModule, "NtWriteVirtualMemory");
+                if (nullptr == sNtWriteVirtualMemory)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtWriteVirtualMemory, 5,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress,
+                (UINT64)aBuffer,
+                (UINT64)aBufferSize,
+                (UINT64)aNumberOfBytesWritten);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64FlushInstructionCache64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_opt_            PVOID64     aBaseAddress,
+        _In_                UINT64      aLength
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            PVOID64 sNtFlushInstructionCache = nullptr;
+            if (nullptr == sNtFlushInstructionCache)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtFlushInstructionCache = Wow64GetProcAddress64(vModule, "NtFlushInstructionCache");
+                if (nullptr == sNtFlushInstructionCache)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtFlushInstructionCache, 3,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress,
+                (UINT64)aLength);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64MapViewOfSection64(
+        _In_                HANDLE64        aSectionHandle,
+        _In_                HANDLE64        aProcessHandle,
+        _Inout_bytecap_(*aViewSize) PVOID64 * aBaseAddress,
+        _In_                UINT64          aZeroBits,
+        _In_                UINT64          aCommitSize,
+        _Inout_opt_         PLARGE_INTEGER  aSectionOffset,
+        _Inout_             PUINT64         aViewSize,
+        _In_                SECTION_INHERIT aInheritDisposition,
+        _In_                UINT32          aAllocationType,
+        _In_                UINT32          aWin32Protect
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            PVOID64 sNtMapViewOfSection = nullptr;
+            if (nullptr == sNtMapViewOfSection)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtMapViewOfSection = Wow64GetProcAddress64(vModule, "NtMapViewOfSection");
+                if (nullptr == sNtMapViewOfSection)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtMapViewOfSection, 10,
+                (UINT64)aSectionHandle,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress,
+                (UINT64)aZeroBits,
+                (UINT64)aCommitSize,
+                (UINT64)aSectionOffset,
+                (UINT64)aViewSize,
+                (UINT64)aInheritDisposition,
+                (UINT64)aAllocationType,
+                (UINT64)aWin32Protect);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64UnmapViewOfSection64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_opt_            PVOID64     aBaseAddress
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            PVOID64 sNtUnmapViewOfSection = nullptr;
+            if (nullptr == sNtUnmapViewOfSection)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtUnmapViewOfSection = Wow64GetProcAddress64(vModule, "NtUnmapViewOfSection");
+                if (nullptr == sNtUnmapViewOfSection)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtUnmapViewOfSection, 2,
+                (UINT64)aProcessHandle,
+                (UINT64)aBaseAddress);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64GetContextThread64(
+        _In_                HANDLE64    aThreadHandle,
+        _Out_               PCONTEXT64  aThreadContext
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            PVOID64 sNtGetContextThread = nullptr;
+            if (nullptr == sNtGetContextThread)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtGetContextThread = Wow64GetProcAddress64(vModule, "NtGetContextThread");
+                if (nullptr == sNtGetContextThread)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtGetContextThread, 2,
+                (UINT64)aThreadHandle,
+                (UINT64)aThreadContext);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64SetContextThread64(
+        _In_                HANDLE64    aThreadHandle,
+        _In_                PCONTEXT64  aThreadContext
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            PVOID64 sNtSetContextThread = nullptr;
+            if (nullptr == sNtSetContextThread)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtSetContextThread = Wow64GetProcAddress64(vModule, "NtSetContextThread");
+                if (nullptr == sNtSetContextThread)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtSetContextThread, 2,
+                (UINT64)aThreadHandle,
+                (UINT64)aThreadContext);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64QueryInformationProcess64(
+        _In_                HANDLE64                    aProcessHandle,
+        _In_                PROCESSINFOCLASS            aProcessInformationClass,
+        _Out_writes_bytes_(aProcessInformationBytes) PVOID aProcessInformation,
+        _In_                UINT32                      aProcessInformationBytes,
+        _Out_opt_           PUINT32                     aReturnLength
+    )
+    {
+        NTSTATUS vStatus = STATUS_SUCCESS;
+
+        for (;;)
+        {
+            PVOID64 sNtQueryInformationProcess = nullptr;
+            if (nullptr == sNtQueryInformationProcess)
+            {
+                auto vModule = Wow64GetNtdll64();
+                if (nullptr == vModule)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+
+                sNtQueryInformationProcess = Wow64GetProcAddress64(vModule, "NtQueryInformationProcess");
+                if (nullptr == sNtQueryInformationProcess)
+                {
+                    return STATUS_NOT_SUPPORTED;
+                }
+            }
+
+            vStatus = (NTSTATUS)Wow64Call64(sNtQueryInformationProcess, 5,
+                (UINT64)aProcessHandle,
+                (UINT64)aProcessInformationClass,
+                (UINT64)aProcessInformation,
+                (UINT64)aProcessInformationBytes,
+                (UINT64)aReturnLength);
+
+            break;
+        }
+
+        return Wow64SetLastErrorFromNtStatus(vStatus);
+    }
+
+    wow64ext_pub UINT64  wow64ext_api Wow64VirtualQueryEx64(
+        _In_                HANDLE64                    aProcess,
+        _In_                PVOID64                     aBaseAddress,
+        _Out_               PMEMORY_BASIC_INFORMATION   aBuffer,
+        _In_                UINT64                      aBytes
+    )
+    {
+        UINT64 vReturnBytes = 0;
+        if (!NT_SUCCESS(NtWow64QueryVirtualMemory64(
+            aProcess, aBaseAddress, MemoryBasicInformation, aBuffer, aBytes, &vReturnBytes)))
+        {
             return 0;
-        WATCH(tempBuf);
-        getMem64(tempBuf, head.BaseDllName.Buffer, head.BaseDllName.MaximumLength);
+        }
 
-        if (0 == _wcsicmp(lpModuleName, tempBuf))
-            return head.DllBase;
+        return vReturnBytes;
     }
-    while (head.InLoadOrderLinks.Flink != LastEntry);
 
-    return 0;
-}
-
-DWORD64 getNTDLL64()
-{
-    static DWORD64 ntdll64 = 0;
-    if (0 != ntdll64)
-        return ntdll64;
-
-    ntdll64 = GetModuleHandle64(L"ntdll.dll");
-    return ntdll64;
-}
-
-DWORD64 getLdrGetProcedureAddress()
-{
-    DWORD64 modBase = getNTDLL64();
-	if (0 == modBase)
-		return 0;
-    
-    IMAGE_DOS_HEADER idh;
-    getMem64(&idh, modBase, sizeof(idh));
-
-    IMAGE_NT_HEADERS64 inh;
-    getMem64(&inh, modBase + idh.e_lfanew, sizeof(IMAGE_NT_HEADERS64));
-    
-    IMAGE_DATA_DIRECTORY& idd = inh.OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT];
-    
-    if (0 == idd.VirtualAddress)
-        return 0;
-
-    IMAGE_EXPORT_DIRECTORY ied;
-    getMem64(&ied, modBase + idd.VirtualAddress, sizeof(ied));
-
-    DWORD* rvaTable = (DWORD*)malloc(sizeof(DWORD)*ied.NumberOfFunctions);
-    if (nullptr == rvaTable)
-        return 0;
-    WATCH(rvaTable);
-    getMem64(rvaTable, modBase + ied.AddressOfFunctions, sizeof(DWORD)*ied.NumberOfFunctions);
-    
-    WORD* ordTable = (WORD*)malloc(sizeof(WORD)*ied.NumberOfFunctions);
-    if (nullptr == ordTable)
-        return 0;
-    WATCH(ordTable);
-    getMem64(ordTable, modBase + ied.AddressOfNameOrdinals, sizeof(WORD)*ied.NumberOfFunctions);
-
-    DWORD* nameTable = (DWORD*)malloc(sizeof(DWORD)*ied.NumberOfNames);
-    if (nullptr == nameTable)
-        return 0;
-    WATCH(nameTable);
-    getMem64(nameTable, modBase + ied.AddressOfNames, sizeof(DWORD)*ied.NumberOfNames);
-
-    // lazy search, there is no need to use binsearch for just one function
-    for (DWORD i = 0; i < ied.NumberOfFunctions; i++)
+    wow64ext_pub PVOID64 wow64ext_api Wow64VirtualAllocEx64(
+        _In_                HANDLE64    aProcess,
+        _In_opt_            PVOID64     aBaseAddress,
+        _In_                UINT64      aSize,
+        _In_                UINT32      aAllocationType,
+        _In_                UINT32      aProtect
+    )
     {
-        if (!cmpMem64((void*)"LdrGetProcedureAddress", modBase + nameTable[i], sizeof("LdrGetProcedureAddress")))
-            continue;
-        else
-            return modBase + rvaTable[ordTable[i]];
+        PVOID64 vBaseAddress    = aBaseAddress;
+        UINT64  vRegionSize     = aSize;
+        if (!NT_SUCCESS(NtWow64AllocateVirtualMemory64(
+            aProcess, &vBaseAddress, 0, &vRegionSize, aAllocationType, aProtect)))
+        {
+            return nullptr;
+        }
+
+        return vBaseAddress;
     }
-    return 0;
-}
 
-VOID __cdecl SetLastErrorFromX64Call(DWORD64 status)
-{
-	typedef ULONG (WINAPI *RtlNtStatusToDosError_t)(NTSTATUS Status);
-	typedef ULONG (WINAPI *RtlSetLastWin32Error_t)(NTSTATUS Status);
-
-	static RtlNtStatusToDosError_t RtlNtStatusToDosError = nullptr;
-	static RtlSetLastWin32Error_t RtlSetLastWin32Error = nullptr;
-
-	if ((nullptr == RtlNtStatusToDosError) || (nullptr == RtlSetLastWin32Error))
-	{
-		HMODULE ntdll = GetModuleHandleW(L"ntdll.dll");
-		RtlNtStatusToDosError = (RtlNtStatusToDosError_t)GetProcAddress(ntdll, "RtlNtStatusToDosError");
-		RtlSetLastWin32Error = (RtlSetLastWin32Error_t)GetProcAddress(ntdll, "RtlSetLastWin32Error");
-	}
-	
-	if ((nullptr != RtlNtStatusToDosError) && (nullptr != RtlSetLastWin32Error))
-	{
-		RtlSetLastWin32Error(RtlNtStatusToDosError((DWORD)status));
-	}
-}
-
-DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, const char* funcName)
-{
-    static DWORD64 _LdrGetProcedureAddress = 0;
-    if (0 == _LdrGetProcedureAddress)
+    wow64ext_pub BOOL    wow64ext_api Wow64VirtualFreeEx64(
+        _In_                HANDLE64    aProcess,
+        _In_                PVOID64     aBaseAddress,
+        _In_                UINT64      aSize,
+        _In_                UINT32      aFreeType
+    )
     {
-        _LdrGetProcedureAddress = getLdrGetProcedureAddress();
-        if (0 == _LdrGetProcedureAddress)
-            return 0;
-    }
+        PVOID64 vBaseAddress    = aBaseAddress;
+        UINT64  vRegionSize     = aSize;
+        if (!NT_SUCCESS(NtWow64FreeVirtualMemory64(
+            aProcess, &vBaseAddress, &vRegionSize, aFreeType)))
+        {
+            return FALSE;
+        }
 
-    _UNICODE_STRING_T<DWORD64> fName = { 0 };
-    fName.Buffer = (DWORD64)funcName;
-    fName.Length = (WORD)strlen(funcName);
-    fName.MaximumLength = fName.Length + 1;
-    DWORD64 funcRet = 0;
-    X64Call(_LdrGetProcedureAddress, 4, (DWORD64)hModule, (DWORD64)&fName, (DWORD64)0, (DWORD64)&funcRet);
-    return funcRet;
-}
-
-SIZE_T __cdecl VirtualQueryEx64(HANDLE hProcess, DWORD64 lpAddress, MEMORY_BASIC_INFORMATION64* lpBuffer, SIZE_T dwLength)
-{
-    static DWORD64 ntqvm = 0;
-    if (0 == ntqvm)
-    {
-        ntqvm = GetProcAddress64(getNTDLL64(), "NtQueryVirtualMemory");
-        if (0 == ntqvm)
-            return 0;
-    }
-    DWORD64 ret = 0;
-    DWORD64 status = X64Call(ntqvm, 6, (DWORD64)hProcess, lpAddress, (DWORD64)0, (DWORD64)lpBuffer, (DWORD64)dwLength, (DWORD64)&ret);
-	if (STATUS_SUCCESS != status)
-		SetLastErrorFromX64Call(status);
-	return (SIZE_T)ret;
-}
-
-DWORD64 __cdecl VirtualAllocEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect)
-{
-    static DWORD64 ntavm = 0;
-    if (0 == ntavm)
-    {
-        ntavm = GetProcAddress64(getNTDLL64(), "NtAllocateVirtualMemory");
-        if (0 == ntavm)
-            return 0;
-    }
-
-    DWORD64 tmpAddr = lpAddress;
-    DWORD64 tmpSize = dwSize;
-    DWORD64 ret = X64Call(ntavm, 6, (DWORD64)hProcess, (DWORD64)&tmpAddr, (DWORD64)0, (DWORD64)&tmpSize, (DWORD64)flAllocationType, (DWORD64)flProtect);
-	if (STATUS_SUCCESS != ret)
-	{
-		SetLastErrorFromX64Call(ret);
-		return FALSE;
-	}
-    else
-        return tmpAddr;
-}
-
-BOOL __cdecl VirtualFreeEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD dwFreeType)
-{
-    static DWORD64 ntfvm = 0;
-    if (0 == ntfvm)
-    {
-        ntfvm = GetProcAddress64(getNTDLL64(), "NtFreeVirtualMemory");
-        if (0 == ntfvm)
-            return 0;
-    }
-
-    DWORD64 tmpAddr = lpAddress;
-    DWORD64 tmpSize = dwSize;
-    DWORD64 ret = X64Call(ntfvm, 4, (DWORD64)hProcess, (DWORD64)&tmpAddr, (DWORD64)&tmpSize, (DWORD64)dwFreeType);
-	if (STATUS_SUCCESS != ret)
-	{
-		SetLastErrorFromX64Call(ret);
-		return FALSE;
-	}
-    else
         return TRUE;
-}
-
-BOOL __cdecl VirtualProtectEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD flNewProtect, DWORD* lpflOldProtect)
-{
-    static DWORD64 ntpvm = 0;
-    if (0 == ntpvm)
-    {
-        ntpvm = GetProcAddress64(getNTDLL64(), "NtProtectVirtualMemory");
-        if (0 == ntpvm)
-            return 0;
     }
 
-    DWORD64 tmpAddr = lpAddress;
-    DWORD64 tmpSize = dwSize;
-    DWORD64 ret = X64Call(ntpvm, 5, (DWORD64)hProcess, (DWORD64)&tmpAddr, (DWORD64)&tmpSize, (DWORD64)flNewProtect, (DWORD64)lpflOldProtect);
-	if (STATUS_SUCCESS != ret)
-	{
-		SetLastErrorFromX64Call(ret);
-		return FALSE;
-	}
-    else
-        return TRUE;
-}
+    wow64ext_pub BOOL    wow64ext_api Wow64VirtualProtectEx64(
+        _In_                HANDLE64    aProcess,
+        _In_                PVOID64     aBaseAddress,
+        _In_                UINT64      aSize,
+        _In_                UINT32      aNewProtect,
+        _Out_               PUINT32     aOldProtect
+    )
+    {
+        PVOID64 vBaseAddress    = aBaseAddress;
+        UINT64  vRegionSize     = aSize;
+        if (!NT_SUCCESS(NtWow64ProtectVirtualMemory64(
+            aProcess, &vBaseAddress, &vRegionSize, aNewProtect, aOldProtect)))
+        {
+            return FALSE;
+        }
 
-BOOL __cdecl ReadProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesRead)
-{
-    static DWORD64 nrvm = 0;
-    if (0 == nrvm)
-    {
-        nrvm = GetProcAddress64(getNTDLL64(), "NtReadVirtualMemory");
-        if (0 == nrvm)
-            return 0;
-    }
-    DWORD64 numOfBytes = lpNumberOfBytesRead ? *lpNumberOfBytesRead : 0;
-    DWORD64 ret = X64Call(nrvm, 5, (DWORD64)hProcess, lpBaseAddress, (DWORD64)lpBuffer, (DWORD64)nSize, (DWORD64)&numOfBytes);
-	if (STATUS_SUCCESS != ret)
-	{
-		SetLastErrorFromX64Call(ret);
-		return FALSE;
-	}
-    else
-    {
-        if (lpNumberOfBytesRead)
-            *lpNumberOfBytesRead = (SIZE_T)numOfBytes;
         return TRUE;
     }
-}
 
-BOOL __cdecl WriteProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesWritten)
-{
-    static DWORD64 nrvm = 0;
-    if (0 == nrvm)
+    wow64ext_pub BOOL    wow64ext_api Wow64ReadProcessMemory64(
+        _In_                HANDLE64    aProcess,
+        _In_                PVOID64     aBaseAddress,
+        _Out_               PVOID       aBuffer,
+        _In_                UINT64      aSize,
+        _Out_               PUINT64     aNumberOfBytesRead
+    )
     {
-        nrvm = GetProcAddress64(getNTDLL64(), "NtWriteVirtualMemory");
-        if (0 == nrvm)
-            return 0;
-    }
-    DWORD64 numOfBytes = lpNumberOfBytesWritten ? *lpNumberOfBytesWritten : 0;
-    DWORD64 ret = X64Call(nrvm, 5, (DWORD64)hProcess, lpBaseAddress, (DWORD64)lpBuffer, (DWORD64)nSize, (DWORD64)&numOfBytes);
-	if (STATUS_SUCCESS != ret)
-	{
-		SetLastErrorFromX64Call(ret);
-		return FALSE;
-	}
-    else
-    {
-        if (lpNumberOfBytesWritten)
-            *lpNumberOfBytesWritten = (SIZE_T)numOfBytes;
+        if (!NT_SUCCESS(NtWow64ReadVirtualMemory64(
+            aProcess, aBaseAddress, aBuffer, aSize, aNumberOfBytesRead)))
+        {
+            return FALSE;
+        }
+
         return TRUE;
     }
-}
 
-BOOL __cdecl GetThreadContext64(HANDLE hThread, _CONTEXT64* lpContext)
-{
-    static DWORD64 gtc = 0;
-    if (0 == gtc)
+    wow64ext_pub BOOL    wow64ext_api Wow64WriteProcessMemory64(
+        _In_                HANDLE64    aProcess,
+        _In_                PVOID64     aBaseAddress,
+        _In_                PVOID       aBuffer,
+        _In_                UINT64      aSize,
+        _Out_               PUINT64     aNumberOfBytesWritten
+    )
     {
-        gtc = GetProcAddress64(getNTDLL64(), "NtGetContextThread");
-        if (0 == gtc)
-            return 0;
-    }
-    DWORD64 ret = X64Call(gtc, 2, (DWORD64)hThread, (DWORD64)lpContext);
-	if(STATUS_SUCCESS != ret)
-	{
-		SetLastErrorFromX64Call(ret);
-		return FALSE;
-	}
-    else
-        return TRUE;
-}
+        if (!NT_SUCCESS(NtWow64WriteVirtualMemory64(
+            aProcess, aBaseAddress, aBuffer, aSize, aNumberOfBytesWritten)))
+        {
+            return FALSE;
+        }
 
-BOOL __cdecl SetThreadContext64(HANDLE hThread, _CONTEXT64* lpContext)
-{
-    static DWORD64 stc = 0;
-    if (0 == stc)
-    {
-        stc = GetProcAddress64(getNTDLL64(), "NtSetContextThread");
-        if (0 == stc)
-            return 0;
-    }
-    DWORD64 ret = X64Call(stc, 2, (DWORD64)hThread, (DWORD64)lpContext);
-	if (STATUS_SUCCESS != ret)
-	{
-		SetLastErrorFromX64Call(ret);
-		return FALSE;
-	}
-    else
         return TRUE;
+    }
+
+    wow64ext_pub BOOL    wow64ext_api Wow64GetThreadContext64(
+        _In_                HANDLE64    aThread,
+        _Out_               PCONTEXT64  aContext
+    )
+    {
+        if (!NT_SUCCESS(NtWow64GetContextThread64(aThread, aContext)))
+        {
+            return FALSE;
+        }
+
+        return TRUE;
+    }
+
+    wow64ext_pub BOOL    wow64ext_api Wow64SetThreadContext64(
+        _In_                HANDLE64    aThread,
+        _In_                PCONTEXT64  aContext
+    )
+    {
+        if (!NT_SUCCESS(NtWow64SetContextThread64(aThread, aContext)))
+        {
+            return FALSE;
+        }
+
+        return TRUE;
+    }
 }

--- a/XAntiDebug/wow64ext.h
+++ b/XAntiDebug/wow64ext.h
@@ -360,8 +360,8 @@ struct _CONTEXT64
 extern "C"
 {
 	DWORD64 __cdecl X64Call(DWORD64 func, int argC, ...);
-	DWORD64 __cdecl GetModuleHandle64(wchar_t* lpModuleName);
-	DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, char* funcName);
+	DWORD64 __cdecl GetModuleHandle64(const wchar_t* lpModuleName);
+	DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, const char* funcName);
 	SIZE_T __cdecl VirtualQueryEx64(HANDLE hProcess, DWORD64 lpAddress, MEMORY_BASIC_INFORMATION64* lpBuffer, SIZE_T dwLength);
 	DWORD64 __cdecl VirtualAllocEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect);
 	BOOL __cdecl VirtualFreeEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD dwFreeType);

--- a/XAntiDebug/wow64ext.h
+++ b/XAntiDebug/wow64ext.h
@@ -1,376 +1,241 @@
 /**
- *
- * WOW64Ext Library
- *
- * Copyright (c) 2014 ReWolf
- * http://blog.rewolf.pl/
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License as published
- * by the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Lesser General Public License for more details.
- *
- * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- */
+*
+* WOW64Ext Library
+*
+* Copyright (c) 2014 ReWolf
+* http://blog.rewolf.pl/
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License as published
+* by the Free Software Foundation, either version 3 of the License, or
+* (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU Lesser General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+
+
 #pragma once
+#include "sdkext.h"
 
-#include <windows.h>
 
-#ifndef STATUS_SUCCESS
-#   define STATUS_SUCCESS 0
+#ifdef _WIN64
+#error Cannot compile in 64-bit environment!
 #endif
 
-#pragma pack(push)
-#pragma pack(1)
-template <class T>
-struct _LIST_ENTRY_T
-{
-    T Flink;
-    T Blink;
-};
-
-template <class T>
-struct _UNICODE_STRING_T
-{
-    union
-    {
-        struct
-        {
-            WORD Length;
-            WORD MaximumLength;
-        };
-        T dummy;
-    };
-    T Buffer;
-};
-
-template <class T>
-struct _NT_TIB_T
-{
-    T ExceptionList;
-    T StackBase;
-    T StackLimit;
-    T SubSystemTib;
-    T FiberData;
-    T ArbitraryUserPointer;
-    T Self;
-};
-
-template <class T>
-struct _CLIENT_ID
-{
-    T UniqueProcess;
-    T UniqueThread;
-};
-
-template <class T>
-struct _TEB_T_
-{
-    _NT_TIB_T<T> NtTib;
-    T EnvironmentPointer;
-    _CLIENT_ID<T> ClientId;
-    T ActiveRpcHandle;
-    T ThreadLocalStoragePointer;
-    T ProcessEnvironmentBlock;
-    DWORD LastErrorValue;
-    DWORD CountOfOwnedCriticalSections;
-    T CsrClientThread;
-    T Win32ThreadInfo;
-    DWORD User32Reserved[26];
-    //rest of the structure is not defined for now, as it is not needed
-};
-
-template <class T>
-struct _LDR_DATA_TABLE_ENTRY_T
-{
-    _LIST_ENTRY_T<T> InLoadOrderLinks;
-    _LIST_ENTRY_T<T> InMemoryOrderLinks;
-    _LIST_ENTRY_T<T> InInitializationOrderLinks;
-    T DllBase;
-    T EntryPoint;
-    union
-    {
-        DWORD SizeOfImage;
-        T dummy01;
-    };
-    _UNICODE_STRING_T<T> FullDllName;
-    _UNICODE_STRING_T<T> BaseDllName;
-    DWORD Flags;
-    WORD LoadCount;
-    WORD TlsIndex;
-    union
-    {
-        _LIST_ENTRY_T<T> HashLinks;
-        struct 
-        {
-            T SectionPointer;
-            T CheckSum;
-        };
-    };
-    union
-    {
-        T LoadedImports;
-        DWORD TimeDateStamp;
-    };
-    T EntryPointActivationContext;
-    T PatchInformation;
-    _LIST_ENTRY_T<T> ForwarderLinks;
-    _LIST_ENTRY_T<T> ServiceTagLinks;
-    _LIST_ENTRY_T<T> StaticLinks;
-    T ContextInformation;
-    T OriginalBase;
-    _LARGE_INTEGER LoadTime;
-};
-
-template <class T>
-struct _PEB_LDR_DATA_T
-{
-    DWORD Length;
-    DWORD Initialized;
-    T SsHandle;
-    _LIST_ENTRY_T<T> InLoadOrderModuleList;
-    _LIST_ENTRY_T<T> InMemoryOrderModuleList;
-    _LIST_ENTRY_T<T> InInitializationOrderModuleList;
-    T EntryInProgress;
-    DWORD ShutdownInProgress;
-    T ShutdownThreadId;
-
-};
-
-template <class T, class NGF, int A>
-struct _PEB_T
-{
-    union
-    {
-        struct
-        {
-            BYTE InheritedAddressSpace;
-            BYTE ReadImageFileExecOptions;
-            BYTE BeingDebugged;
-            BYTE BitField;
-        };
-        T dummy01;
-    };
-    T Mutant;
-    T ImageBaseAddress;
-    T Ldr;
-    T ProcessParameters;
-    T SubSystemData;
-    T ProcessHeap;
-    T FastPebLock;
-    T AtlThunkSListPtr;
-    T IFEOKey;
-    T CrossProcessFlags;
-    T UserSharedInfoPtr;
-    DWORD SystemReserved;
-    DWORD AtlThunkSListPtr32;
-    T ApiSetMap;
-    T TlsExpansionCounter;
-    T TlsBitmap;
-    DWORD TlsBitmapBits[2];
-    T ReadOnlySharedMemoryBase;
-    T HotpatchInformation;
-    T ReadOnlyStaticServerData;
-    T AnsiCodePageData;
-    T OemCodePageData;
-    T UnicodeCaseTableData;
-    DWORD NumberOfProcessors;
-    union
-    {
-        DWORD NtGlobalFlag;
-        NGF dummy02;
-    };
-    LARGE_INTEGER CriticalSectionTimeout;
-    T HeapSegmentReserve;
-    T HeapSegmentCommit;
-    T HeapDeCommitTotalFreeThreshold;
-    T HeapDeCommitFreeBlockThreshold;
-    DWORD NumberOfHeaps;
-    DWORD MaximumNumberOfHeaps;
-    T ProcessHeaps;
-    T GdiSharedHandleTable;
-    T ProcessStarterHelper;
-    T GdiDCAttributeList;
-    T LoaderLock;
-    DWORD OSMajorVersion;
-    DWORD OSMinorVersion;
-    WORD OSBuildNumber;
-    WORD OSCSDVersion;
-    DWORD OSPlatformId;
-    DWORD ImageSubsystem;
-    DWORD ImageSubsystemMajorVersion;
-    T ImageSubsystemMinorVersion;
-    T ActiveProcessAffinityMask;
-    T GdiHandleBuffer[A];
-    T PostProcessInitRoutine; 
-    T TlsExpansionBitmap; 
-    DWORD TlsExpansionBitmapBits[32];
-    T SessionId;
-    ULARGE_INTEGER AppCompatFlags;
-    ULARGE_INTEGER AppCompatFlagsUser;
-    T pShimData;
-    T AppCompatInfo;
-    _UNICODE_STRING_T<T> CSDVersion;
-    T ActivationContextData;
-    T ProcessAssemblyStorageMap;
-    T SystemDefaultActivationContextData;
-    T SystemAssemblyStorageMap;
-    T MinimumStackCommit;
-    T FlsCallback;
-    _LIST_ENTRY_T<T> FlsListHead;
-    T FlsBitmap;
-    DWORD FlsBitmapBits[4];
-    T FlsHighIndex;
-    T WerRegistrationData;
-    T WerShipAssertPtr;
-    T pContextData;
-    T pImageHeaderHash;
-    T TracingFlags;
-};
-
-typedef _LDR_DATA_TABLE_ENTRY_T<DWORD> LDR_DATA_TABLE_ENTRY32;
-typedef _LDR_DATA_TABLE_ENTRY_T<DWORD64> LDR_DATA_TABLE_ENTRY64;
-
-typedef _TEB_T_<DWORD> TEB32;
-typedef _TEB_T_<DWORD64> TEB64;
-
-typedef _PEB_LDR_DATA_T<DWORD> PEB_LDR_DATA32;
-typedef _PEB_LDR_DATA_T<DWORD64> PEB_LDR_DATA64;
-
-typedef _PEB_T<DWORD, DWORD64, 34> PEB32;
-typedef _PEB_T<DWORD64, DWORD, 30> PEB64;
-
-struct _XSAVE_FORMAT64
-{
-    WORD ControlWord;
-    WORD StatusWord;
-    BYTE TagWord;
-    BYTE Reserved1;
-    WORD ErrorOpcode;
-    DWORD ErrorOffset;
-    WORD ErrorSelector;
-    WORD Reserved2;
-    DWORD DataOffset;
-    WORD DataSelector;
-    WORD Reserved3;
-    DWORD MxCsr;
-    DWORD MxCsr_Mask;
-    _M128A FloatRegisters[8];
-    _M128A XmmRegisters[16];
-    BYTE Reserved4[96];
-};
-
-struct _CONTEXT64
-{
-    DWORD64 P1Home;
-    DWORD64 P2Home;
-    DWORD64 P3Home;
-    DWORD64 P4Home;
-    DWORD64 P5Home;
-    DWORD64 P6Home;
-    DWORD ContextFlags;
-    DWORD MxCsr;
-    WORD SegCs;
-    WORD SegDs;
-    WORD SegEs;
-    WORD SegFs;
-    WORD SegGs;
-    WORD SegSs;
-    DWORD EFlags;
-    DWORD64 Dr0;
-    DWORD64 Dr1;
-    DWORD64 Dr2;
-    DWORD64 Dr3;
-    DWORD64 Dr6;
-    DWORD64 Dr7;
-    DWORD64 Rax;
-    DWORD64 Rcx;
-    DWORD64 Rdx;
-    DWORD64 Rbx;
-    DWORD64 Rsp;
-    DWORD64 Rbp;
-    DWORD64 Rsi;
-    DWORD64 Rdi;
-    DWORD64 R8;
-    DWORD64 R9;
-    DWORD64 R10;
-    DWORD64 R11;
-    DWORD64 R12;
-    DWORD64 R13;
-    DWORD64 R14;
-    DWORD64 R15;
-    DWORD64 Rip;
-    _XSAVE_FORMAT64 FltSave;
-    _M128A Header[2];
-    _M128A Legacy[8];
-    _M128A Xmm0;
-    _M128A Xmm1;
-    _M128A Xmm2;
-    _M128A Xmm3;
-    _M128A Xmm4;
-    _M128A Xmm5;
-    _M128A Xmm6;
-    _M128A Xmm7;
-    _M128A Xmm8;
-    _M128A Xmm9;
-    _M128A Xmm10;
-    _M128A Xmm11;
-    _M128A Xmm12;
-    _M128A Xmm13;
-    _M128A Xmm14;
-    _M128A Xmm15;
-    _M128A VectorRegister[26];
-    DWORD64 VectorControl;
-    DWORD64 DebugControl;
-    DWORD64 LastBranchToRip;
-    DWORD64 LastBranchFromRip;
-    DWORD64 LastExceptionToRip;
-    DWORD64 LastExceptionFromRip;
-};
-
-// Below defines for .ContextFlags field are taken from WinNT.h
-#ifndef CONTEXT_AMD64
-#define CONTEXT_AMD64 0x100000
-#endif
-
-#define CONTEXT64_CONTROL (CONTEXT_AMD64 | 0x1L)
-#define CONTEXT64_INTEGER (CONTEXT_AMD64 | 0x2L)
-#define CONTEXT64_SEGMENTS (CONTEXT_AMD64 | 0x4L)
-#define CONTEXT64_FLOATING_POINT  (CONTEXT_AMD64 | 0x8L)
-#define CONTEXT64_DEBUG_REGISTERS (CONTEXT_AMD64 | 0x10L)
-#define CONTEXT64_FULL (CONTEXT64_CONTROL | CONTEXT64_INTEGER | CONTEXT64_FLOATING_POINT)
-#define CONTEXT64_ALL (CONTEXT64_CONTROL | CONTEXT64_INTEGER | CONTEXT64_SEGMENTS | CONTEXT64_FLOATING_POINT | CONTEXT64_DEBUG_REGISTERS)
-#define CONTEXT64_XSTATE (CONTEXT_AMD64 | 0x20L)
-
-#pragma pack(pop)
-
-#ifdef WOW64EXT_EXPORTS
-#   define SPEC dllexport
+#ifdef _WINDLL
+#   define wow64ext_api __cdecl
+#   define wow64ext_pub extern"C" __declspec(dllexport)
 #else
-#   define SPEC dllimport
+#   define wow64ext_api __cdecl
+#   define wow64ext_pub extern"C"
 #endif
 
-extern "C"
+
+namespace wow64ext
 {
-	DWORD64 __cdecl X64Call(DWORD64 func, int argC, ...);
-	DWORD64 __cdecl GetModuleHandle64(const wchar_t* lpModuleName);
-	DWORD64 __cdecl GetProcAddress64(DWORD64 hModule, const char* funcName);
-	SIZE_T __cdecl VirtualQueryEx64(HANDLE hProcess, DWORD64 lpAddress, MEMORY_BASIC_INFORMATION64* lpBuffer, SIZE_T dwLength);
-	DWORD64 __cdecl VirtualAllocEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD flAllocationType, DWORD flProtect);
-	BOOL __cdecl VirtualFreeEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD dwFreeType);
-	BOOL __cdecl VirtualProtectEx64(HANDLE hProcess, DWORD64 lpAddress, SIZE_T dwSize, DWORD flNewProtect, DWORD* lpflOldProtect);
-	BOOL __cdecl ReadProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesRead);
-	BOOL __cdecl WriteProcessMemory64(HANDLE hProcess, DWORD64 lpBaseAddress, LPVOID lpBuffer, SIZE_T nSize, SIZE_T *lpNumberOfBytesWritten);
-	BOOL __cdecl GetThreadContext64(HANDLE hThread, _CONTEXT64* lpContext);
-	BOOL __cdecl SetThreadContext64(HANDLE hThread, _CONTEXT64* lpContext);
-	VOID __cdecl SetLastErrorFromX64Call(DWORD64 status);
-	BOOL InitWow64Ext();
-	void getMem64(void* dstMem, DWORD64 srcMem, size_t sz);
+
+    using namespace sdkext;
+    
+    wow64ext_pub auto wow64ext_api Wow64CopyMemory64(
+        _Out_bytecap_(aBytes)   PVOID64 aDst,
+        _In_bytecount_(aBytes)  PVOID64 aSrc,
+        _In_                    UINT64  aBytes
+    )->VOID;
+
+    wow64ext_pub auto wow64ext_api Wow64CompareMemory64(
+        _In_bytecount_(aBytes)  PVOID64 aDst,
+        _In_bytecount_(aBytes)  PVOID64 aSrc,
+        _In_                    UINT64  aBytes
+    )->bool;
+
+    wow64ext_pub auto wow64ext_api Wow64Call64(
+        _In_                    PVOID64 aFunc,
+        _In_                    int     aArgsCount,
+        _In_opt_                ...     /*Args*/
+    )->UINT64;
+
+    wow64ext_pub auto wow64ext_api ZwWow64CurrentTeb64(
+    )->PVOID64 /*TEB64*/;
+
+    wow64ext_pub auto wow64ext_api ZwWow64CurrentPeb64(
+    )->PVOID64 /*PEB64*/;
+    
+    wow64ext_pub auto wow64ext_api Wow64GetModuleHandle64(
+        _In_                    LPCWSTR aModuleName
+    )->PVOID64;
+
+    wow64ext_pub auto wow64ext_api Wow64GetNtdll64(
+    )->PVOID64;
+
+    wow64ext_pub auto wow64ext_api Wow64GetLdrGetProcedureAddress64(
+    )->PVOID64;
+
+    wow64ext_pub auto wow64ext_api Wow64GetProcAddress64(
+        _In_                    PVOID64 aModule,
+        _In_                    LPCSTR  aProcName
+    )->PVOID64;
+
+    wow64ext_pub auto wow64ext_api Wow64SetLastErrorFromNtStatus(
+        NTSTATUS    aStatus
+    )->NTSTATUS;
+
+}
+
+namespace wow64ext
+{
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64QueryVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_                PVOID64     aBaseAddress,
+        _In_ MEMORY_INFORMATION_CLASS   aMemoryInformationClass,
+        _Out_writes_bytes_(aMemoryInformationBytes) PVOID aMemoryInformation,
+        _In_                UINT64      aMemoryInformationBytes,
+        _Out_opt_           PUINT64     aReturnLength
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64AllocateVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_bytecount_(*aRegionSize) PVOID64* aBaseAddress,
+        _In_                UINT64      aZeroBits,
+        _Inout_             PUINT64     aRegionSize,
+        _In_                UINT32      aAllocationType,
+        _In_                UINT32      aProtect
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64FreeVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _Inout_             PVOID64*    aBaseAddress,
+        _Inout_             PUINT64     aRegionSize,
+        _In_                UINT32       aFreeType
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64ProtectVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _Inout_             PVOID64 *   aBaseAddress,
+        _Inout_             PUINT64     aRegionSize,
+        _In_                UINT32      aNewProtect,
+        _Out_               PUINT32     aOldProtect
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64ReadVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_opt_            PVOID64     aBaseAddress,
+        _Out_writes_bytes_(aBufferSize) PVOID aBuffer,
+        _In_                UINT64      aBufferSize,
+        _Out_opt_           PUINT64     aNumberOfBytesRead
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64WriteVirtualMemory64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_opt_            PVOID64     aBaseAddress,
+        _In_reads_bytes_(aBufferSize)   PVOID aBuffer,
+        _In_                UINT64      aBufferSize,
+        _Out_opt_           PUINT64     aNumberOfBytesWritten
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64FlushInstructionCache64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_opt_            PVOID64     aBaseAddress,
+        _In_                UINT64      aLength
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64MapViewOfSection64(
+        _In_                HANDLE64        aSectionHandle,
+        _In_                HANDLE64        aProcessHandle,
+        _Inout_bytecap_(*aViewSize) PVOID64 * aBaseAddress,
+        _In_                UINT64          aZeroBits,
+        _In_                UINT64          aCommitSize,
+        _Inout_opt_         PLARGE_INTEGER  aSectionOffset,
+        _Inout_             PUINT64         aViewSize,
+        _In_                SECTION_INHERIT aInheritDisposition,
+        _In_                UINT32          aAllocationType,
+        _In_                UINT32          aWin32Protect
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64UnmapViewOfSection64(
+        _In_                HANDLE64    aProcessHandle,
+        _In_opt_            PVOID64     aBaseAddress
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64GetContextThread64(
+        _In_                HANDLE64    aThreadHandle,
+        _Out_               PCONTEXT64  aThreadContext
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64SetContextThread64(
+        _In_                HANDLE64    aThreadHandle,
+        _In_                PCONTEXT64  aThreadContext
+    );
+
+    wow64ext_pub NTSTATUS wow64ext_api NtWow64QueryInformationProcess64(
+        _In_                HANDLE64                    aProcessHandle,
+        _In_                PROCESSINFOCLASS            aProcessInformationClass,
+        _Out_writes_bytes_(aProcessInformationBytes) PVOID aProcessInformation,
+        _In_                UINT32                      aProcessInformationBytes,
+        _Out_opt_           PUINT32                     aReturnLength
+    );
+
+    wow64ext_pub UINT64  wow64ext_api Wow64VirtualQueryEx64(
+        _In_                HANDLE64                    aProcess,
+        _In_                PVOID64                     aBaseAddress,
+        _Out_               PMEMORY_BASIC_INFORMATION   aBuffer,
+        _In_                UINT64                      aBytes
+    );
+
+    wow64ext_pub PVOID64 wow64ext_api Wow64VirtualAllocEx64(
+        _In_                HANDLE64    aProcess,
+        _In_opt_            PVOID64     aBaseAddress,
+        _In_                UINT64      aSize,
+        _In_                UINT32      aAllocationType,
+        _In_                UINT32      aProtect
+    );
+
+    wow64ext_pub BOOL    wow64ext_api Wow64VirtualFreeEx64(
+        _In_                HANDLE64    aProcess,
+        _In_                PVOID64     aBaseAddress,
+        _In_                UINT64      aSize,
+        _In_                UINT32      aFreeType
+    );
+
+    wow64ext_pub BOOL    wow64ext_api Wow64VirtualProtectEx64(
+        _In_                HANDLE64    aProcess,
+        _In_                PVOID64     aBaseAddress,
+        _In_                UINT64      aSize,
+        _In_                UINT32      aNewProtect,
+        _Out_               PUINT32     aOldProtect
+    );
+
+    wow64ext_pub BOOL    wow64ext_api Wow64ReadProcessMemory64(
+        _In_                HANDLE64    aProcess,
+        _In_                PVOID64     aBaseAddress,
+        _Out_               PVOID       aBuffer,
+        _In_                UINT64      aSize,
+        _Out_               PUINT64     aNumberOfBytesRead
+    );
+
+    wow64ext_pub BOOL    wow64ext_api Wow64WriteProcessMemory64(
+        _In_                HANDLE64    aProcess,
+        _In_                PVOID64     aBaseAddress,
+        _In_                PVOID       aBuffer,
+        _In_                UINT64      aSize,
+        _Out_               PUINT64     aNumberOfBytesWritten
+    );
+
+    wow64ext_pub BOOL    wow64ext_api Wow64GetThreadContext64(
+        _In_                HANDLE64    aThread,
+        _Out_               PCONTEXT64  aContext
+    );
+
+    wow64ext_pub BOOL    wow64ext_api Wow64SetThreadContext64(
+        _In_                HANDLE64    aThread,
+        _In_                PCONTEXT64  aContext
+    );
+
 }

--- a/test.cpp.sln.DotSettings.user
+++ b/test.cpp.sln.DotSettings.user
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpAutoNaming/IsNamingAutoDetectionCompleted/@EntryValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/CodeStyle/Naming/CSharpAutoNaming/IsNotificationDisabled/@EntryValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/test.cpp.vcxproj
+++ b/test.cpp.vcxproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -27,26 +27,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v141</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v141_xp</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>

--- a/test.cpp.vcxproj
+++ b/test.cpp.vcxproj
@@ -158,6 +158,7 @@
     <ClInclude Include="XAntiDebug\crc32.h" />
     <ClInclude Include="XAntiDebug\internal.h" />
     <ClInclude Include="XAntiDebug\ldasm.h" />
+    <ClInclude Include="XAntiDebug\sdkext.h" />
     <ClInclude Include="XAntiDebug\wow64ext.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</ExcludedFromBuild>

--- a/test.cpp.vcxproj.filters
+++ b/test.cpp.vcxproj.filters
@@ -53,5 +53,8 @@
     <ClInclude Include="XAntiDebug\crc32.h">
       <Filter>XAntiDebug</Filter>
     </ClInclude>
+    <ClInclude Include="XAntiDebug\sdkext.h">
+      <Filter>XAntiDebug</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
三个问题：
1：_CRT_SECURE_NO_WARNINGS
2：char\*改const char\*
4：char\*显式转换为void\*